### PR TITLE
safe details/messages: clarify cases with empty formats

### DIFF
--- a/barriers/barriers.go
+++ b/barriers/barriers.go
@@ -97,7 +97,7 @@ func (e *barrierError) Format(s fmt.State, verb rune) { errbase.FormatError(e, s
 func (e *barrierError) FormatError(p errbase.Printer) (next error) {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("\noriginal cause behind barrier:\n%+v", e.maskedErr)
+		p.Printf("\noriginal cause behind barrier: %+v", e.maskedErr)
 	}
 	return nil
 }

--- a/barriers/barriers_test.go
+++ b/barriers/barriers_test.go
@@ -113,34 +113,27 @@ func TestFormat(t *testing.T) {
 	}{
 		{"handled", barriers.Handled(goErr.New("woo")), woo, `
 woo:
-    original cause behind barrier:
-    woo`},
+    original cause behind barrier: woo`},
 
 		{"handled + handled", barriers.Handled(barriers.Handled(goErr.New("woo"))), woo, `
 woo:
-    original cause behind barrier:
-    woo:
-        original cause behind barrier:
-        woo`},
+    original cause behind barrier: woo:
+        original cause behind barrier: woo`},
 
 		{"handledmsg", barriers.HandledWithMessage(goErr.New("woo"), "waa"), "waa", `
 waa:
-    original cause behind barrier:
-    woo`},
+    original cause behind barrier: woo`},
 
 		{"handledmsg + handledmsg", barriers.HandledWithMessage(
 			barriers.HandledWithMessage(
 				goErr.New("woo"), "waa"), "wuu"), `wuu`, `
 wuu:
-    original cause behind barrier:
-    waa:
-        original cause behind barrier:
-        woo`},
+    original cause behind barrier: waa:
+        original cause behind barrier: woo`},
 
 		{"handled + wrapper", barriers.Handled(&werrFmt{goErr.New("woo"), "waa"}), waawoo, `
 waa: woo:
-    original cause behind barrier:
-    waa:
+    original cause behind barrier: waa:
         -- verbose wrapper:
         waa
       - woo`},

--- a/errutil/message_test.go
+++ b/errutil/message_test.go
@@ -135,8 +135,7 @@ assertion failure
     runtime.goexit
     <tab><path>
   - wuu: woo:
-    original cause behind barrier:
-    wuu:
+    original cause behind barrier: wuu:
         -- verbose wrapper:
         wuu
       - woo`,
@@ -157,8 +156,7 @@ assertion failure
     -- arg 1: <string>
   - waa: hello:
   - wuu: woo:
-    original cause behind barrier:
-    wuu:
+    original cause behind barrier: wuu:
         -- verbose wrapper:
         wuu
       - woo`,
@@ -176,8 +174,7 @@ assertion failure
     runtime.goexit
     <tab><path>
   - wuu: woo:
-    original cause behind barrier:
-    wuu:
+    original cause behind barrier: wuu:
         -- verbose wrapper:
         wuu
       - woo`,
@@ -198,8 +195,7 @@ assertion failure
     -- arg 1: <int>
   - %!(EXTRA int=123):
   - wuu: woo:
-    original cause behind barrier:
-    wuu:
+    original cause behind barrier: wuu:
         -- verbose wrapper:
         wuu
       - woo`,

--- a/errutil/message_test.go
+++ b/errutil/message_test.go
@@ -122,6 +122,26 @@ error with attached stack trace:
   - woo`,
 		},
 
+		{"handled assert",
+			errutil.HandleAsAssertionFailure(&werrFmt{goErr.New("woo"), "wuu"}),
+			`wuu: woo`,
+			`
+assertion failure
+  - error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestFormat
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - wuu: woo:
+    original cause behind barrier:
+    wuu:
+        -- verbose wrapper:
+        wuu
+      - woo`,
+		},
+
 		{"assert + wrap",
 			errutil.NewAssertionErrorWithWrappedErrf(&werrFmt{goErr.New("woo"), "wuu"}, "waa: %s", "hello"),
 			`waa: hello: wuu: woo`, `

--- a/errutil/message_test.go
+++ b/errutil/message_test.go
@@ -49,6 +49,34 @@ error with attached stack trace:
   - waa: hello`,
 		},
 
+		{"newf-empty",
+			errutil.Newf(emptyString),
+			``, `
+error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestFormat
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - `,
+		},
+
+		{"newf-empty-arg",
+			errutil.Newf(emptyString, 123),
+			`%!(EXTRA int=123)`, `
+error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestFormat
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - error with embedded safe details:
+    -- arg 1: <int>
+  - %!(EXTRA int=123)`,
+		},
+
 		{"wrapf",
 			errutil.Wrapf(goErr.New("woo"), "waa: %s", "hello"),
 			`waa: hello: woo`, `
@@ -62,6 +90,35 @@ error with attached stack trace:
   - error with embedded safe details: waa: %s
     -- arg 1: <string>
   - waa: hello:
+  - woo`,
+		},
+
+		{"wrapf-empty",
+			errutil.Wrapf(goErr.New("woo"), emptyString),
+			`woo`, `
+error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestFormat
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - woo`,
+		},
+
+		{"wrapf-empty-arg",
+			errutil.Wrapf(goErr.New("woo"), emptyString, 123),
+			`%!(EXTRA int=123): woo`, `
+error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestFormat
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - error with embedded safe details:
+    -- arg 1: <int>
+  - %!(EXTRA int=123):
   - woo`,
 		},
 
@@ -79,6 +136,47 @@ assertion failure
   - error with embedded safe details: waa: %s
     -- arg 1: <string>
   - waa: hello:
+  - wuu: woo:
+    original cause behind barrier:
+    wuu:
+        -- verbose wrapper:
+        wuu
+      - woo`,
+		},
+
+		{"assert + wrap empty",
+			errutil.NewAssertionErrorWithWrappedErrf(&werrFmt{goErr.New("woo"), "wuu"}, emptyString),
+			`wuu: woo`, `
+assertion failure
+  - error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestFormat
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - wuu: woo:
+    original cause behind barrier:
+    wuu:
+        -- verbose wrapper:
+        wuu
+      - woo`,
+		},
+
+		{"assert + wrap empty+arg",
+			errutil.NewAssertionErrorWithWrappedErrf(&werrFmt{goErr.New("woo"), "wuu"}, emptyString, 123),
+			`%!(EXTRA int=123): wuu: woo`, `
+assertion failure
+  - error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestFormat
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - error with embedded safe details:
+    -- arg 1: <int>
+  - %!(EXTRA int=123):
   - wuu: woo:
     original cause behind barrier:
     wuu:
@@ -131,3 +229,5 @@ func (e *werrFmt) FormatError(p errbase.Printer) error {
 	}
 	return e.cause
 }
+
+var emptyString = ""

--- a/errutil/utilities.go
+++ b/errutil/utilities.go
@@ -55,7 +55,9 @@ func Newf(format string, args ...interface{}) error {
 // See the doc of `New()` for more details.
 func NewWithDepthf(depth int, format string, args ...interface{}) error {
 	err := fmt.Errorf(format, args...)
-	err = safedetails.WithSafeDetails(err, format, args...)
+	if format != "" || len(args) > 0 {
+		err = safedetails.WithSafeDetails(err, format, args...)
+	}
 	err = withstack.WithStackDepth(err, 1+depth)
 	return err
 }
@@ -100,10 +102,10 @@ func Wrapf(err error, format string, args ...interface{}) error {
 // trace is configurable.
 // The the doc of `Wrapf()` for more details.
 func WrapWithDepthf(depth int, err error, format string, args ...interface{}) error {
-	if format != "" {
+	if format != "" || len(args) > 0 {
 		err = WithMessagef(err, format, args...)
+		err = safedetails.WithSafeDetails(err, format, args...)
 	}
-	err = safedetails.WithSafeDetails(err, format, args...)
 	err = withstack.WithStackDepth(err, depth+1)
 	return err
 }

--- a/errutil_api.go
+++ b/errutil_api.go
@@ -105,5 +105,15 @@ func NewAssertionErrorWithWrappedErrf(origErr error, format string, args ...inte
 	return errutil.NewAssertionErrorWithWrappedErrDepthf(1, origErr, format, args...)
 }
 
+// HandleAsAssertionFailure forwards a definition.
+func HandleAsAssertionFailure(origErr error) error {
+	return errutil.HandleAsAssertionFailureDepth(1, origErr)
+}
+
+// HandleAsAssertionFailureDepth forwards a definition.
+func HandleAsAssertionFailureDepth(depth int, origErr error) error {
+	return errutil.HandleAsAssertionFailureDepth(1+depth, origErr)
+}
+
 // As forwards a definition
 func As(err error, target interface{}) bool { return errutil.As(err, target) }

--- a/safedetails/safedetails_test.go
+++ b/safedetails/safedetails_test.go
@@ -87,6 +87,19 @@ func TestFormat(t *testing.T) {
 error with embedded safe details: a
   - woo`},
 
+		{"safe empty",
+			safedetails.WithSafeDetails(baseErr, ""),
+			woo, `
+safe detail wrapper with no details
+  - woo`},
+
+		{"safe nofmt+onearg",
+			safedetails.WithSafeDetails(baseErr, "", 123),
+			woo, `
+error with embedded safe details:
+    -- arg 1: <int>
+  - woo`},
+
 		{"safe err",
 			safedetails.WithSafeDetails(baseErr, "a %v",
 				&os.PathError{

--- a/safedetails/with_safedetails.go
+++ b/safedetails/with_safedetails.go
@@ -39,10 +39,17 @@ var _ errbase.Formatter = (*withSafeDetails)(nil)
 func (e *withSafeDetails) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
 
 func (e *withSafeDetails) FormatError(p errbase.Printer) error {
-	if p.Detail() && len(e.safeDetails) > 0 {
-		p.Printf("error with embedded safe details: %s", e.safeDetails[0])
-		for _, d := range e.safeDetails[1:] {
-			p.Printf("\n%s", d)
+	if p.Detail() {
+		if len(e.safeDetails) == 0 || (len(e.safeDetails) == 1 && e.safeDetails[0] == "") {
+			p.Print("safe detail wrapper with no details")
+		} else {
+			p.Print("error with embedded safe details:")
+			if e.safeDetails[0] != "" {
+				p.Printf(" %s", e.safeDetails[0])
+			}
+			for _, d := range e.safeDetails[1:] {
+				p.Printf("\n%s", d)
+			}
 		}
 	}
 	return e.cause


### PR DESCRIPTION
- when format is empty but there are additional arguments, still
  perform the formatting (the values will be included)
- when format is empty and there are no additional argument,
  make the safe detail wrapper present itself as "empty"
  during `%+v` formatting
- additionally a new primitive `HandleAsAssertionFailure()` to avoid `NewAssertionErrorWithWrappedErrf(err, "")` and a surprising empty string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/3)
<!-- Reviewable:end -->
