### PR TITLE
fixed readme exemple of Wrap function

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ they behave as no-ops in this case:
 // return nil
 //
 // is not needed. Instead, you can use this:
-return errors.Wrap(foo())
+return errors.Wrap(foo(), "foo")
 ```
 
 - `Wrap(error, string) error`, `Wrapf(error, string, ...interface{}) error`:


### PR DESCRIPTION
[Wrap Example](https://github.com/cockroachdb/errors#available-wrapper-constructors) in the  README seemed to be wrong.
Since I added an argument, please check that my recognition is correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/7)
<!-- Reviewable:end -->
