### PR TITLE
make the errors library compatible with go 1.13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: go
 
 go:
 - 1.12.x
+- 1.13.x

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Table of contents:
 | error causes (`Cause` / `Unwrap`)                                                                     |                     | ✔                       | ✔                          | ✔                    |
 | cause barriers (`Opaque` / `Handled`)                                                                 |                     |                         | ✔                          | ✔                    |
 | `errors.As()`, `errors.Is()`                                                                          |                     |                         | ✔                          | ✔                    |
+| automatic error wrap when format ends with `: %w`                                                     |                     |                         | ✔                          | ✔                    |
 | standard wrappers with efficient stack trace capture                                                  |                     | ✔                       |                            | ✔                    |
 | **transparent protobuf encode/decode with forward compatibility**                                     |                     |                         |                            | ✔                    |
 | **`errors.Is()` recognizes errors across the network**                                                |                     |                         |                            | ✔                    |
@@ -44,7 +45,7 @@ Table of contents:
 | wrappers for user-facing hints and details                                                            |                     |                         |                            | ✔                    |
 | wrappers to attach secondary causes                                                                   |                     |                         |                            | ✔                    |
 | wrappers to attach [`logtags`](https://github.com/cockroachdb/logtags) details from `context.Context` |                     |                         |                            | ✔                    |
-| `errors.FormatError()`, `Formatter`, `Printer`                                                        |                     |                         | ✔                          | (under construction) |
+| `errors.FormatError()`, `Formatter`, `Printer`                                                        |                     |                         | (under construction)       | (under construction) |
 
 "Forward compatibility" above refers to the ability of this library to
 recognize and properly handle network communication of error types it

--- a/errutil/fmt_wrap_test.go
+++ b/errutil/fmt_wrap_test.go
@@ -1,0 +1,121 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build go1.13
+
+package errutil_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors/errutil"
+	"github.com/cockroachdb/errors/testutils"
+)
+
+func TestErrorWrap(t *testing.T) {
+	tt := testutils.T{t}
+
+	baseErr := errutil.New("world")
+
+	testCases := []struct {
+		name          string
+		err           error
+		expFmtSimple  string
+		expFmtVerbose string
+	}{
+		{"fmt wrap err",
+			fmt.Errorf("hello: %w", baseErr),
+			`hello: world`,
+			// This fails to reveal the errors details because
+			// fmt.Error's error objects do not implement a full %+v.
+			`hello: world`},
+
+		{"fmt rewrap err",
+			errutil.Wrap(fmt.Errorf("hello: %w", baseErr), "woo"),
+			`woo: hello: world`,
+			// However, ours do.
+			`error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - woo:
+  - hello
+  - error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - world`},
+
+		{"new wrap err",
+			errutil.Newf("hello: %w", baseErr),
+			`hello: world`,
+			`error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - error with embedded safe details: hello: %w
+    -- arg 1: <*errors.errorString>
+    wrapper: <*withstack.withStack>
+    (more details:)
+    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - hello
+  - error with attached stack trace:
+    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
+    <tab><path>
+    testing.tRunner
+    <tab><path>
+    runtime.goexit
+    <tab><path>
+  - world`},
+	}
+
+	for _, test := range testCases {
+		tt.Run(test.name, func(tt testutils.T) {
+			err := test.err
+
+			// %s is simple formatting
+			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+
+			// %v is simple formatting too, for compatibility with the past.
+			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+
+			// %q is always like %s but quotes the result.
+			ref := fmt.Sprintf("%q", test.expFmtSimple)
+			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+
+			// %+v is the verbose mode.
+			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
+			spv := fmt.Sprintf("%+v", err)
+			spv = fileref.ReplaceAllString(spv, "<path>")
+			spv = strings.ReplaceAll(spv, "\t", "<tab>")
+			tt.CheckEqual(spv, refV)
+		})
+	}
+}

--- a/errutil/message_test.go
+++ b/errutil/message_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package errutil_test
 
 import (

--- a/safedetails/redact_go112.go
+++ b/safedetails/redact_go112.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !go1.13
+
+package safedetails
+
+import (
+	"net"
+	"os"
+	"strings"
+)
+
+func redactPre113Wrappers(buf *strings.Builder, err error) bool {
+	// The following cases are needed for go 1.12 and previous
+	// versions. Go 1.13 instances of these errors will be recognized
+	// by the unwrapping performed in redactErr().
+	switch t := err.(type) {
+	case *os.SyscallError:
+		redactErr(buf, t.Err)
+		redactWrapper(buf, err)
+		return true
+	case *os.PathError:
+		redactErr(buf, t.Err)
+		redactWrapper(buf, err)
+		return true
+	case *net.OpError:
+		redactErr(buf, t.Err)
+		redactWrapper(buf, err)
+		return true
+	case *os.LinkError:
+		redactErr(buf, t.Err)
+		redactWrapper(buf, err)
+		return true
+	}
+	return false
+}

--- a/safedetails/redact_go113.go
+++ b/safedetails/redact_go113.go
@@ -1,0 +1,23 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build go1.13
+
+package safedetails
+
+import "strings"
+
+func redactPre113Wrappers(buf *strings.Builder, err error) bool {
+	return false
+}

--- a/safedetails/safedetails_test.go
+++ b/safedetails/safedetails_test.go
@@ -109,7 +109,8 @@ error with embedded safe details:
 				}),
 			woo, `
 error with embedded safe details: a %v
-    -- arg 1: *os.PathError: open <redacted>: file does not exist
+    -- arg 1: *errors.errorString: file does not exist
+    wrapper: *os.PathError: open
   - woo`},
 
 		{"safe",
@@ -140,6 +141,28 @@ waa:
   - error with embedded safe details: a %s %s
     -- arg 1: <string>
     -- arg 2: c
+  - woo`},
+
+		{"safe with wrapped error",
+			safedetails.WithSafeDetails(baseErr, "a %v",
+				&werrFmt{errors.New("wuu"), "waa"}),
+			woo,
+			`error with embedded safe details: a %v
+    -- arg 1: <*errors.errorString>
+    wrapper: <*safedetails_test.werrFmt>
+  - woo`},
+
+		{"safe in safe",
+			safedetails.WithSafeDetails(baseErr, "a %v",
+				safedetails.WithSafeDetails(errors.New("wuu"),
+					"b %v", safedetails.Safe("waa"))),
+			woo,
+			`error with embedded safe details: a %v
+    -- arg 1: <*errors.errorString>
+    wrapper: <*safedetails.withSafeDetails>
+    (more details:)
+    b %v
+    -- arg 1: waa
   - woo`},
 	}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/8)
<!-- Reviewable:end -->
