### PR TITLE
Fix the compatibility Cause() API.

### DIFF
--- a/errutil_api.go
+++ b/errutil_api.go
@@ -42,7 +42,7 @@ func Errorf(format string, args ...interface{}) error {
 }
 
 // Cause is provided for compatibility with github.com/pkg/errors.
-func Cause(err error) error { return errbase.UnwrapOnce(err) }
+func Cause(err error) error { return errbase.UnwrapAll(err) }
 
 // Unwrap is provided for compatibility with xerrors.
 func Unwrap(err error) error { return errbase.UnwrapOnce(err) }


### PR DESCRIPTION
pkg/errors has Cause unwrap everything. Our previous implementation
was thus incorrect. This patch fixes it.

(Discovered while trying to upgrade crdb's `client.Txn` to use this package, see CI failures in https://github.com/cockroachdb/cockroach/pull/42854 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/17)
<!-- Reviewable:end -->
