### PR TITLE
markers: Properly separate IsType() and HasType()

### DIFF
--- a/markers/example_is_type_test.go
+++ b/markers/example_is_type_test.go
@@ -29,13 +29,19 @@ func (e *ExampleError) Error() string { return e.msg }
 func ExampleIsType() {
 	base := &ExampleError{"world"}
 	err := errors.Wrap(base, "hello")
+	fmt.Println(markers.HasType(err, (*ExampleError)(nil)))
 	fmt.Println(markers.IsType(err, (*ExampleError)(nil)))
+	fmt.Println(markers.HasType(err, nil))
 	fmt.Println(markers.IsType(err, nil))
+	fmt.Println(markers.HasType(err, (*net.AddrError)(nil)))
 	fmt.Println(markers.IsType(err, (*net.AddrError)(nil)))
 
 	// Output:
 	//
 	// true
+	// false
+	// false
+	// false
 	// false
 	// false
 }

--- a/markers/markers.go
+++ b/markers/markers.go
@@ -59,14 +59,20 @@ func Is(err, reference error) bool {
 	return false
 }
 
-// IsType returns true if err contains an error which has the concrete type
-// matching that of referenceType.
-func IsType(err error, referenceType error) bool {
+// HasType returns true iff err contains an error whose concrete type
+// matches that of referenceType.
+func HasType(err error, referenceType error) bool {
 	typ := reflect.TypeOf(referenceType)
 	_, isType := If(err, func(err error) (interface{}, bool) {
 		return nil, reflect.TypeOf(err) == typ
 	})
 	return isType
+}
+
+// IsType returns true if the outermost err object has a concrete type
+// matching that of referenceType.
+func IsType(err error, referenceType error) bool {
+	return reflect.TypeOf(err) == reflect.TypeOf(referenceType)
 }
 
 // IsInterface returns true if err contains an error which implements the

--- a/markers/markers_test.go
+++ b/markers/markers_test.go
@@ -246,19 +246,21 @@ func (e *testError) Error() string {
 	return e.msg
 }
 
-func TestIsType(t *testing.T) {
+func TestHasType(t *testing.T) {
 	tt := testutils.T{T: t}
 	base := &testError{msg: "hmm"}
 	wrapped := pkgErr.Wrap(base, "boom")
 
-	tt.Check(!markers.IsType(base, nil))
-	tt.Check(!markers.IsType(wrapped, nil))
+	tt.Check(!markers.HasType(base, nil))
+	tt.Check(!markers.HasType(wrapped, nil))
 
+	tt.Check(markers.HasType(base, (*testError)(nil)))
 	tt.Check(markers.IsType(base, (*testError)(nil)))
-	tt.Check(markers.IsType(wrapped, (*testError)(nil)))
+	tt.Check(markers.HasType(wrapped, (*testError)(nil)))
+	tt.Check(!markers.IsType(wrapped, (*testError)(nil)))
 
 	// nil errors don't contain any types, not even nil.
-	tt.Check(!markers.IsType(nil, nil))
+	tt.Check(!markers.HasType(nil, nil))
 }
 
 type testErrorInterface interface {

--- a/markers_api.go
+++ b/markers_api.go
@@ -22,6 +22,9 @@ func Is(err, reference error) bool { return markers.Is(err, reference) }
 // IsType forwards a definition.
 func IsType(err, referenceType error) bool { return markers.IsType(err, referenceType) }
 
+// HasType forwards a definition.
+func HasType(err, referenceType error) bool { return markers.HasType(err, referenceType) }
+
 // IsInterface forwards a definition.
 func IsInterface(err error, referenceInterface interface{}) bool {
 	return markers.IsInterface(err, referenceInterface)


### PR DESCRIPTION
The Go idiom is IsXXX() for "the tip is XXX" and HasXXX() for "the
error contains XXX in the chain".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/24)
<!-- Reviewable:end -->
