### PR TITLE
Re-vamp the infrastructure for `%+v` formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ older version of the package.
 |-----------------------------------------------------------------|-------------------------------------|--------------|-------------------------------|-----------------------------------|
 | main message, eg `New()`                                        | visible                             | visible      | redacted                      | redacted                          |
 | wrap prefix, eg `WithMessage()`                                 | visible (as prefix)                 | visible      | redacted                      | redacted                          |
-| stack trace, eg `WithStack()`                                   | not visible                         | visible      | yes                           | full                              |
+| stack trace, eg `WithStack()`                                   | not visible                         | simplified   | yes                           | full                              |
 | hint , eg `WithHint()`                                          | not visible                         | visible      | no                            | type only                         |
 | detail, eg `WithDetail()`                                       | not visible                         | visible      | no                            | type only                         |
 | assertion failure annotation, eg `WithAssertionFailure()`       | not visible                         | visible      | no                            | type only                         |
 | issue links, eg `WithIssueLink()`, `UnimplementedError()`       | not visible                         | visible      | yes                           | full                              |
-| safe details, eg `WithSafeDetails()`                            | not visible                         | visible      | yes                           | full                              |
+| safe details, eg `WithSafeDetails()`                            | not visible                         | not visible  | yes                           | full                              |
 | telemetry keys, eg. `WithTelemetryKey()`                        | not visible                         | visible      | yes                           | full                              |
 | secondary errors, eg. `WithSecondaryError()`, `CombineErrors()` | not visible                         | visible      | redacted, recursively         | redacted, recursively             |
 | barrier origins, eg. `Handled()`                                | not visible                         | visible      | redacted, recursively         | redacted, recursively             |

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -62,7 +62,6 @@ type withAssertionFailure struct {
 
 var _ error = (*withAssertionFailure)(nil)
 var _ fmt.Formatter = (*withAssertionFailure)(nil)
-var _ errbase.Formatter = (*withAssertionFailure)(nil)
 
 // ErrorHint implements the hintdetail.ErrorHinter interface.
 func (w *withAssertionFailure) ErrorHint() string {
@@ -76,13 +75,8 @@ func (w *withAssertionFailure) Error() string { return w.cause.Error() }
 func (w *withAssertionFailure) Cause() error  { return w.cause }
 func (w *withAssertionFailure) Unwrap() error { return w.cause }
 
+// Format implements the fmt.Formatter interface.
 func (w *withAssertionFailure) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
-func (w *withAssertionFailure) FormatError(p errbase.Printer) error {
-	if p.Detail() {
-		p.Print("assertion failure")
-	}
-	return w.cause
-}
 
 func decodeAssertFailure(
 	_ context.Context, cause error, _ string, _ []string, _ proto.Message,

--- a/barriers/barriers.go
+++ b/barriers/barriers.go
@@ -97,7 +97,7 @@ func (e *barrierError) Format(s fmt.State, verb rune) { errbase.FormatError(e, s
 func (e *barrierError) FormatError(p errbase.Printer) (next error) {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("\noriginal cause behind barrier: %+v", e.maskedErr)
+		p.Printf("\nhidden cause: %+v", e.maskedErr)
 	}
 	return nil
 }

--- a/barriers/barriers_test.go
+++ b/barriers/barriers_test.go
@@ -97,7 +97,7 @@ func TestHandledWithMessagef(t *testing.T) {
 	b1 := barriers.HandledWithMessage(origErr, "woo woo")
 	b2 := barriers.HandledWithMessagef(origErr, "woo %s", "woo")
 
-	tt.CheckEqual(b1.Error(), b2.Error())
+	tt.CheckStringEqual(b1.Error(), b2.Error())
 }
 
 func TestFormat(t *testing.T) {
@@ -112,31 +112,48 @@ func TestFormat(t *testing.T) {
 		expFmtVerbose string
 	}{
 		{"handled", barriers.Handled(goErr.New("woo")), woo, `
-woo:
-    original cause behind barrier: woo`},
+woo
+- (*barriers.barrierError:) woo
+    hidden cause: woo
+    - (*errors.errorString:) woo`},
 
 		{"handled + handled", barriers.Handled(barriers.Handled(goErr.New("woo"))), woo, `
-woo:
-    original cause behind barrier: woo:
-        original cause behind barrier: woo`},
+woo
+- (*barriers.barrierError:) woo
+    hidden cause: woo
+    - (*barriers.barrierError:) woo
+        hidden cause: woo
+        - (*errors.errorString:) woo`},
 
 		{"handledmsg", barriers.HandledWithMessage(goErr.New("woo"), "waa"), "waa", `
-waa:
-    original cause behind barrier: woo`},
+waa
+- (*barriers.barrierError:) waa
+    hidden cause: woo
+    - (*errors.errorString:) woo`},
 
 		{"handledmsg + handledmsg", barriers.HandledWithMessage(
 			barriers.HandledWithMessage(
 				goErr.New("woo"), "waa"), "wuu"), `wuu`, `
-wuu:
-    original cause behind barrier: waa:
-        original cause behind barrier: woo`},
+wuu
+- (*barriers.barrierError:) wuu
+    hidden cause: waa
+    - (*barriers.barrierError:) waa
+        hidden cause: woo
+        - (*errors.errorString:) woo`},
 
-		{"handled + wrapper", barriers.Handled(&werrFmt{goErr.New("woo"), "waa"}), waawoo, `
-waa: woo:
-    original cause behind barrier: waa:
-        -- verbose wrapper:
-        waa
-      - woo`},
+		{"handled + wrapper",
+			barriers.Handled(
+				&werrFmt{
+					goErr.New("woo"),
+					"waa"}),
+			waawoo, `
+waa: woo
+- (*barriers.barrierError:) waa: woo
+    hidden cause: waa: woo
+    - (*errors.errorString:) woo
+    - (*barriers_test.werrFmt:) waa
+        -- this is waa's
+        multi-line wrapper payload`},
 	}
 
 	for _, test := range testCases {
@@ -144,19 +161,19 @@ waa: woo:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -174,7 +191,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line wrapper payload", e.msg)
 	}
 	return e.cause
 }

--- a/contexttags/contexttags_test.go
+++ b/contexttags/contexttags_test.go
@@ -65,7 +65,7 @@ func TestWithContext(t *testing.T) {
 		tt.Check(markers.Is(err, decoratedErr))
 
 		// Check that the message is preserved.
-		tt.CheckEqual(err.Error(), "hello")
+		tt.CheckStringEqual(err.Error(), "hello")
 
 		// Check that the tag pairs are preserved.
 		tagsets := contexttags.GetContextTags(err)
@@ -143,6 +143,7 @@ func TestFormat(t *testing.T) {
 	tt := testutils.T{t}
 
 	ctx := logtags.AddTag(context.Background(), "thetag", nil)
+	ctx = logtags.AddTag(ctx, "anothertag", nil)
 	baseErr := goErr.New("woo")
 	const woo = `woo`
 	const waawoo = `waa: woo`
@@ -155,26 +156,32 @@ func TestFormat(t *testing.T) {
 		{"tags",
 			contexttags.WithContextTags(baseErr, ctx),
 			woo, `
-error with context tags: thetag
-  - woo`},
+woo
+- (*errors.errorString:) woo
+- (*contexttags.withContext:)
+    tags: [thetag,anothertag]`},
 
 		{"tags + wrapper",
 			contexttags.WithContextTags(&werrFmt{baseErr, "waa"}, ctx),
 			waawoo, `
-error with context tags: thetag
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*contexttags_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload
+- (*contexttags.withContext:)
+    tags: [thetag,anothertag]`},
 
 		{"wrapper + tags",
 			&werrFmt{contexttags.WithContextTags(baseErr, ctx), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - error with context tags: thetag
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*contexttags.withContext:)
+    tags: [thetag,anothertag]
+- (*contexttags_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload`},
 	}
 
 	for _, test := range testCases {
@@ -182,19 +189,19 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -212,7 +219,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/contexttags/with_context.go
+++ b/contexttags/with_context.go
@@ -54,7 +54,7 @@ func (w *withContext) Format(s fmt.State, verb rune) { errbase.FormatError(w, s,
 
 func (w *withContext) FormatError(p errbase.Printer) error {
 	if p.Detail() && w.tags != nil {
-		p.Printf("error with context tags: %s", w.tags.String())
+		p.Printf("tags: [%s]", w.tags.String())
 	}
 	return w.cause
 }

--- a/errutil/fmt_wrap_test.go
+++ b/errutil/fmt_wrap_test.go
@@ -47,53 +47,40 @@ func TestErrorWrap(t *testing.T) {
 			errutil.Wrap(fmt.Errorf("hello: %w", baseErr), "woo"),
 			`woo: hello: world`,
 			// However, ours do.
-			`error with attached stack trace:
+			`woo: hello: world
+- (*errors.errorString:) world
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestErrorWrap
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
     <tab><path>
-  - woo:
-  - hello
-  - error with attached stack trace:
+- (*fmt.wrapError:) hello
+- (*errutil.withMessage:) woo
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestErrorWrap
     <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - world`},
+    [...same entries as above...]`},
 
 		{"new wrap err",
 			errutil.Newf("hello: %w", baseErr),
 			`hello: world`,
-			`error with attached stack trace:
+			`hello: world
+- (*errors.errorString:) world
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestErrorWrap
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
     <tab><path>
-  - error with embedded safe details: hello: %w
-    -- arg 1: <*errors.errorString>
-    wrapper: <*withstack.withStack>
-    (more details:)
+- (*fmt.wrapError:) hello
+- (*safedetails.withSafeDetails:) 2 details enclosed
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestErrorWrap
     <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - hello
-  - error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - world`},
+    [...same entries as above...]`},
 	}
 
 	for _, test := range testCases {
@@ -101,21 +88,21 @@ func TestErrorWrap(t *testing.T) {
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
 			spv = fileref.ReplaceAllString(spv, "<path>")
 			spv = strings.ReplaceAll(spv, "\t", "<tab>")
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }

--- a/errutil/message_test.go
+++ b/errutil/message_test.go
@@ -41,178 +41,187 @@ func TestFormat(t *testing.T) {
 					goErr.New("woo"), "waa"),
 				"wuu"},
 			`wuu: waa: woo`, `
-wuu:
-    -- verbose wrapper:
-    wuu
-  - waa:
-  - woo`,
+wuu: waa: woo
+- (*errors.errorString:) woo
+- (*errutil.withMessage:) waa
+- (*errutil_test.werrFmt:) wuu
+    -- this is wuu's
+    multi-line payload`,
 		},
 
 		{"newf",
 			errutil.Newf("waa: %s", "hello"),
 			`waa: hello`, `
-error with attached stack trace:
+waa: hello
+- (*errors.errorString:) waa: hello
+- (*safedetails.withSafeDetails:) 2 details enclosed
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestFormat
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
-    <tab><path>
-  - error with embedded safe details: waa: %s
-    -- arg 1: <string>
-  - waa: hello`,
+    <tab><path>`,
 		},
 
 		{"newf-empty",
 			errutil.Newf(emptyString),
 			``, `
-error with attached stack trace:
+
+- (*errors.errorString:)
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestFormat
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
-    <tab><path>
-  - `,
+    <tab><path>`,
 		},
 
 		{"newf-empty-arg",
 			errutil.Newf(emptyString, 123),
 			`%!(EXTRA int=123)`, `
-error with attached stack trace:
+%!(EXTRA int=123)
+- (*errors.errorString:) %!(EXTRA int=123)
+- (*safedetails.withSafeDetails:) 2 details enclosed
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestFormat
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
-    <tab><path>
-  - error with embedded safe details:
-    -- arg 1: <int>
-  - %!(EXTRA int=123)`,
+    <tab><path>`,
 		},
 
 		{"wrapf",
 			errutil.Wrapf(goErr.New("woo"), "waa: %s", "hello"),
 			`waa: hello: woo`, `
-error with attached stack trace:
+waa: hello: woo
+- (*errors.errorString:) woo
+- (*errutil.withMessage:) waa: hello
+- (*safedetails.withSafeDetails:) 2 details enclosed
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestFormat
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
-    <tab><path>
-  - error with embedded safe details: waa: %s
-    -- arg 1: <string>
-  - waa: hello:
-  - woo`,
+    <tab><path>`,
 		},
 
 		{"wrapf-empty",
 			errutil.Wrapf(goErr.New("woo"), emptyString),
 			`woo`, `
-error with attached stack trace:
+woo
+- (*errors.errorString:) woo
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestFormat
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
-    <tab><path>
-  - woo`,
+    <tab><path>`,
 		},
 
 		{"wrapf-empty-arg",
 			errutil.Wrapf(goErr.New("woo"), emptyString, 123),
 			`%!(EXTRA int=123): woo`, `
-error with attached stack trace:
+%!(EXTRA int=123): woo
+- (*errors.errorString:) woo
+- (*errutil.withMessage:) %!(EXTRA int=123)
+- (*safedetails.withSafeDetails:) 2 details enclosed
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestFormat
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
-    <tab><path>
-  - error with embedded safe details:
-    -- arg 1: <int>
-  - %!(EXTRA int=123):
-  - woo`,
+    <tab><path>`,
 		},
 
 		{"handled assert",
 			errutil.HandleAsAssertionFailure(&werrFmt{goErr.New("woo"), "wuu"}),
 			`wuu: woo`,
 			`
-assertion failure
-  - error with attached stack trace:
+wuu: woo
+- (*barriers.barrierError:) wuu: woo
+    hidden cause: wuu: woo
+    - (*errors.errorString:) woo
+    - (*errutil_test.werrFmt:) wuu
+        -- this is wuu's
+        multi-line payload
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestFormat
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
     <tab><path>
-  - wuu: woo:
-    original cause behind barrier: wuu:
-        -- verbose wrapper:
-        wuu
-      - woo`,
+- (*assert.withAssertionFailure:)`,
 		},
 
 		{"assert + wrap",
 			errutil.NewAssertionErrorWithWrappedErrf(&werrFmt{goErr.New("woo"), "wuu"}, "waa: %s", "hello"),
 			`waa: hello: wuu: woo`, `
-assertion failure
-  - error with attached stack trace:
+waa: hello: wuu: woo
+- (*barriers.barrierError:) wuu: woo
+    hidden cause: wuu: woo
+    - (*errors.errorString:) woo
+    - (*errutil_test.werrFmt:) wuu
+        -- this is wuu's
+        multi-line payload
+- (*errutil.withMessage:) waa: hello
+- (*safedetails.withSafeDetails:) 2 details enclosed
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestFormat
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
     <tab><path>
-  - error with embedded safe details: waa: %s
-    -- arg 1: <string>
-  - waa: hello:
-  - wuu: woo:
-    original cause behind barrier: wuu:
-        -- verbose wrapper:
-        wuu
-      - woo`,
+- (*assert.withAssertionFailure:)`,
 		},
 
 		{"assert + wrap empty",
 			errutil.NewAssertionErrorWithWrappedErrf(&werrFmt{goErr.New("woo"), "wuu"}, emptyString),
 			`wuu: woo`, `
-assertion failure
-  - error with attached stack trace:
+wuu: woo
+- (*barriers.barrierError:) wuu: woo
+    hidden cause: wuu: woo
+    - (*errors.errorString:) woo
+    - (*errutil_test.werrFmt:) wuu
+        -- this is wuu's
+        multi-line payload
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestFormat
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
     <tab><path>
-  - wuu: woo:
-    original cause behind barrier: wuu:
-        -- verbose wrapper:
-        wuu
-      - woo`,
+- (*assert.withAssertionFailure:)`,
 		},
 
 		{"assert + wrap empty+arg",
 			errutil.NewAssertionErrorWithWrappedErrf(&werrFmt{goErr.New("woo"), "wuu"}, emptyString, 123),
 			`%!(EXTRA int=123): wuu: woo`, `
-assertion failure
-  - error with attached stack trace:
+%!(EXTRA int=123): wuu: woo
+- (*barriers.barrierError:) wuu: woo
+    hidden cause: wuu: woo
+    - (*errors.errorString:) woo
+    - (*errutil_test.werrFmt:) wuu
+        -- this is wuu's
+        multi-line payload
+- (*errutil.withMessage:) %!(EXTRA int=123)
+- (*safedetails.withSafeDetails:) 2 details enclosed
+- (*withstack.withStack:)
     github.com/cockroachdb/errors/errutil_test.TestFormat
     <tab><path>
     testing.tRunner
     <tab><path>
     runtime.goexit
     <tab><path>
-  - error with embedded safe details:
-    -- arg 1: <int>
-  - %!(EXTRA int=123):
-  - wuu: woo:
-    original cause behind barrier: wuu:
-        -- verbose wrapper:
-        wuu
-      - woo`,
+- (*assert.withAssertionFailure:)`,
 		},
 	}
 
@@ -221,21 +230,21 @@ assertion failure
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
 			spv = fileref.ReplaceAllString(spv, "<path>")
 			spv = strings.ReplaceAll(spv, "\t", "<tab>")
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -255,7 +264,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/extgrpc/ext_grpc_test.go
+++ b/extgrpc/ext_grpc_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/extgrpc"
 	"github.com/cockroachdb/errors/testutils"
-
 	"google.golang.org/grpc/codes"
 )
 
@@ -47,10 +46,12 @@ func TestGrpc(t *testing.T) {
 	tt.CheckEqual(extgrpc.GetGrpcCode(otherErr), codes.NotFound)
 
 	// The code is hidden when the error is printed with %v.
-	tt.CheckEqual(fmt.Sprintf("%v", err), `hello`)
+	tt.CheckStringEqual(fmt.Sprintf("%v", err), `hello`)
 	// The code appears when the error is printed verbosely.
-	tt.CheckEqual(fmt.Sprintf("%+v", err), `gRPC code: Unavailable
-  - hello`)
+	tt.CheckStringEqual(fmt.Sprintf("%+v", err), `hello
+- (*errors.errorString:) hello
+- (*extgrpc.withGrpcCode:)
+    gRPC code: Unavailable`)
 
 	// Checking the code of a nil error should be codes.OK
 	var noErr error

--- a/exthttp/ext_http_test.go
+++ b/exthttp/ext_http_test.go
@@ -45,8 +45,10 @@ func TestHTTP(t *testing.T) {
 	tt.CheckEqual(exthttp.GetHTTPCode(otherErr, 100), 404)
 
 	// The code is hidden when the error is printed with %v.
-	tt.CheckEqual(fmt.Sprintf("%v", err), `hello`)
+	tt.CheckStringEqual(fmt.Sprintf("%v", err), `hello`)
 	// The code appears when the error is printed verbosely.
-	tt.CheckEqual(fmt.Sprintf("%+v", err), `http code: 302
-  - hello`)
+	tt.CheckStringEqual(fmt.Sprintf("%+v", err), `hello
+- (*errors.errorString:) hello
+- (*exthttp.withHTTPCode:)
+    http code: 302`)
 }

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/grpc/status"
 	"github.com/cockroachdb/errors/testutils"
-
 	"google.golang.org/grpc/codes"
 )
 
@@ -50,5 +49,7 @@ func TestGrpc(t *testing.T) {
 	tt.Assert(err.Error() == "there was a problem: internal error!")
 	tt.Assert(status.Code(err) == codes.Internal)
 	tt.Assert(errors.Is(err, ErrInternal))
-	tt.Assert(strings.HasPrefix(fmt.Sprintf("%+v", err), "gRPC code: Internal"))
+	spv := fmt.Sprintf("%+v", err)
+	t.Logf("spv:\n%s", spv)
+	tt.Assert(strings.HasSuffix(spv, "gRPC code: Internal"))
 }

--- a/hintdetail/hintdetail_test.go
+++ b/hintdetail/hintdetail_test.go
@@ -47,14 +47,14 @@ func TestDetail(t *testing.T) {
 
 	theTest := func(tt testutils.T, err error) {
 		tt.Check(markers.Is(err, origErr))
-		tt.CheckEqual(err.Error(), "hello: world")
+		tt.CheckStringEqual(err.Error(), "hello: world")
 
 		details := hintdetail.GetAllDetails(err)
 		tt.CheckDeepEqual(details, []string{"foo", "bar"})
 
 		errV := fmt.Sprintf("%+v", err)
-		tt.Check(strings.Contains(errV, "detail: foo"))
-		tt.Check(strings.Contains(errV, "detail: bar"))
+		tt.Check(strings.Contains(errV, "foo"))
+		tt.Check(strings.Contains(errV, "bar"))
 	}
 
 	tt.Run("local", func(tt testutils.T) { theTest(tt, err) })
@@ -84,14 +84,14 @@ func TestHint(t *testing.T) {
 
 	theTest := func(tt testutils.T, err error) {
 		tt.Check(markers.Is(err, origErr))
-		tt.CheckEqual(err.Error(), "hello: world")
+		tt.CheckStringEqual(err.Error(), "hello: world")
 
 		hints := hintdetail.GetAllHints(err)
 		tt.CheckDeepEqual(hints, []string{"foo", "bar"})
 
 		errV := fmt.Sprintf("%+v", err)
-		tt.Check(strings.Contains(errV, "hint: foo"))
-		tt.Check(strings.Contains(errV, "hint: bar"))
+		tt.Check(strings.Contains(errV, "foo"))
+		tt.Check(strings.Contains(errV, "bar"))
 	}
 
 	tt.Run("local", func(tt testutils.T) { theTest(tt, err) })
@@ -114,13 +114,13 @@ func TestIssueLinkHint(t *testing.T) {
 	)
 
 	theTest := func(tt testutils.T, err error) {
-		tt.CheckEqual(err.Error(), "hello world")
+		tt.CheckStringEqual(err.Error(), "hello world")
 
 		hints := hintdetail.GetAllHints(err)
 		tt.Assert(len(hints) == 2)
 
-		tt.CheckEqual(hints[0], "See: foo")
-		tt.CheckEqual(hints[1], "See: bar")
+		tt.CheckStringEqual(hints[0], "See: foo")
+		tt.CheckStringEqual(hints[1], "See: bar")
 	}
 
 	tt.Run("local", func(tt testutils.T) { theTest(tt, err) })
@@ -137,12 +137,12 @@ func TestUnimplementedHint(t *testing.T) {
 	err := issuelink.UnimplementedError(issuelink.IssueLink{IssueURL: "woo"}, "hello world")
 
 	theTest := func(tt testutils.T, err error) {
-		tt.CheckEqual(err.Error(), "hello world")
+		tt.CheckStringEqual(err.Error(), "hello world")
 
 		hints := hintdetail.GetAllHints(err)
 		tt.Assert(len(hints) > 0)
 
-		tt.CheckEqual(hints[0], issuelink.UnimplementedErrorHint+"\nSee: woo")
+		tt.CheckStringEqual(hints[0], issuelink.UnimplementedErrorHint+"\nSee: woo")
 	}
 
 	tt.Run("local", func(tt testutils.T) { theTest(tt, err) })
@@ -159,12 +159,12 @@ func TestUnimplementedNoIssueHint(t *testing.T) {
 	err := issuelink.UnimplementedError(issuelink.IssueLink{}, "hello world")
 
 	theTest := func(tt testutils.T, err error) {
-		tt.CheckEqual(err.Error(), "hello world")
+		tt.CheckStringEqual(err.Error(), "hello world")
 
 		hints := hintdetail.GetAllHints(err)
 		tt.Assert(len(hints) > 0)
 
-		tt.CheckEqual(hints[0], issuelink.UnimplementedErrorHint+stdstrings.IssueReferral)
+		tt.CheckStringEqual(hints[0], issuelink.UnimplementedErrorHint+stdstrings.IssueReferral)
 	}
 
 	tt.Run("local", func(tt testutils.T) { theTest(tt, err) })
@@ -181,12 +181,12 @@ func TestAssertionHints(t *testing.T) {
 	err := assert.WithAssertionFailure(errors.New("hello world"))
 
 	theTest := func(tt testutils.T, err error) {
-		tt.CheckEqual(err.Error(), "hello world")
+		tt.CheckStringEqual(err.Error(), "hello world")
 
 		hints := hintdetail.GetAllHints(err)
 		tt.Assert(len(hints) > 0)
 
-		tt.CheckEqual(hints[0], assert.AssertionErrorHint+stdstrings.IssueReferral)
+		tt.CheckStringEqual(hints[0], assert.AssertionErrorHint+stdstrings.IssueReferral)
 	}
 
 	tt.Run("local", func(tt testutils.T) { theTest(tt, err) })
@@ -204,11 +204,11 @@ func TestMultiHintDetail(t *testing.T) {
 	err = hintdetail.WithHint(err, "woo")
 	err = hintdetail.WithHint(err, "waa")
 
-	tt.CheckEqual(hintdetail.FlattenHints(err), "woo\n--\nwaa")
+	tt.CheckStringEqual(hintdetail.FlattenHints(err), "woo\n--\nwaa")
 
 	err = hintdetail.WithDetail(err, "foo")
 	err = hintdetail.WithDetail(err, "bar")
-	tt.CheckEqual(hintdetail.FlattenDetails(err), "foo\n--\nbar")
+	tt.CheckStringEqual(hintdetail.FlattenDetails(err), "foo\n--\nbar")
 }
 
 func TestFormat(t *testing.T) {
@@ -226,48 +226,60 @@ func TestFormat(t *testing.T) {
 		{"hint",
 			hintdetail.WithHint(baseErr, "a"),
 			woo, `
-error with user hint: a
-  - woo`},
+woo
+- (*errors.errorString:) woo
+- (*hintdetail.withHint:)
+    a`},
 		{"detail",
 			hintdetail.WithDetail(baseErr, "a"),
 			woo, `
-error with user detail: a
-  - woo`},
+woo
+- (*errors.errorString:) woo
+- (*hintdetail.withDetail:)
+    a`},
 
 		{"hint + wrapper",
 			hintdetail.WithHint(&werrFmt{baseErr, "waa"}, "a"),
 			waawoo, `
-error with user hint: a
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*hintdetail_test.werrFmt:) waa
+    -- this is waa's
+    multi-line wrapper
+- (*hintdetail.withHint:)
+    a`},
 
 		{"detail + wrapper",
 			hintdetail.WithDetail(&werrFmt{baseErr, "waa"}, "a"),
 			waawoo, `
-error with user detail: a
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*hintdetail_test.werrFmt:) waa
+    -- this is waa's
+    multi-line wrapper
+- (*hintdetail.withDetail:)
+    a`},
 
 		{"wrapper + hint",
 			&werrFmt{hintdetail.WithHint(baseErr, "a"), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - error with user hint: a
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*hintdetail.withHint:)
+    a
+- (*hintdetail_test.werrFmt:) waa
+    -- this is waa's
+    multi-line wrapper`},
 		{"wrapper + detail",
 			&werrFmt{hintdetail.WithDetail(baseErr, "a"), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - error with user detail: a
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*hintdetail.withDetail:)
+    a
+- (*hintdetail_test.werrFmt:) waa
+    -- this is waa's
+    multi-line wrapper`},
 	}
 
 	for _, test := range testCases {
@@ -275,19 +287,19 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -305,7 +317,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line wrapper", e.msg)
 	}
 	return e.cause
 }

--- a/hintdetail/with_detail.go
+++ b/hintdetail/with_detail.go
@@ -42,7 +42,7 @@ func (w *withDetail) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, 
 
 func (w *withDetail) FormatError(p errbase.Printer) error {
 	if p.Detail() {
-		p.Printf("error with user detail: %s", w.detail)
+		p.Print(w.detail)
 	}
 	return w.cause
 }

--- a/hintdetail/with_hint.go
+++ b/hintdetail/with_hint.go
@@ -42,7 +42,7 @@ func (w *withHint) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, ve
 
 func (w *withHint) FormatError(p errbase.Printer) error {
 	if p.Detail() {
-		p.Printf("error with user hint: %s", w.hint)
+		p.Print(w.hint)
 	}
 	return w.cause
 }

--- a/issuelink/issuelink_test.go
+++ b/issuelink/issuelink_test.go
@@ -44,7 +44,7 @@ func TestIssueLink(t *testing.T) {
 
 	theTest := func(tt testutils.T, err error) {
 		tt.Check(markers.Is(err, origErr))
-		tt.CheckEqual(err.Error(), "hello: world")
+		tt.CheckStringEqual(err.Error(), "hello: world")
 
 		tt.Check(issuelink.HasIssueLink(err))
 		if _, ok := markers.If(err, func(err error) (interface{}, bool) { return nil, issuelink.IsIssueLink(err) }); !ok {
@@ -89,36 +89,40 @@ func TestFormat(t *testing.T) {
 		{"link",
 			issuelink.WithIssueLink(baseErr, link),
 			woo, `
-error with linked issue
-    issue: http://mysite
-  - woo`},
+woo
+- (*errors.errorString:) woo
+- (*issuelink.withIssueLink:)
+    issue: http://mysite`},
 		{"link-details",
 			issuelink.WithIssueLink(baseErr, issuelink.IssueLink{IssueURL: "http://mysite", Detail: "see more"}),
 			woo, `
-error with linked issue
+woo
+- (*errors.errorString:) woo
+- (*issuelink.withIssueLink:)
     issue: http://mysite
-    detail: see more
-  - woo`},
+    detail: see more`},
 
 		{"link + wrapper",
 			issuelink.WithIssueLink(&werrFmt{baseErr, "waa"}, link),
 			waawoo, `
-error with linked issue
-    issue: http://mysite
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*issuelink_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload
+- (*issuelink.withIssueLink:)
+    issue: http://mysite`},
 
 		{"wrapper + link",
 			&werrFmt{issuelink.WithIssueLink(baseErr, link), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - error with linked issue
+waa: woo
+- (*errors.errorString:) woo
+- (*issuelink.withIssueLink:)
     issue: http://mysite
-  - woo`},
+- (*issuelink_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload`},
 	}
 
 	for _, test := range testCases {
@@ -126,19 +130,19 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -156,7 +160,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/issuelink/unimplemented_error.go
+++ b/issuelink/unimplemented_error.go
@@ -54,7 +54,6 @@ func (w *unimplementedError) Format(s fmt.State, verb rune) { errbase.FormatErro
 func (w *unimplementedError) FormatError(p errbase.Printer) error {
 	p.Print(w.msg)
 	if p.Detail() {
-		p.Print("\n(unimplemented error)")
 		if w.IssueURL != "" {
 			p.Printf("\nissue: %s", w.IssueURL)
 		}

--- a/issuelink/unimplemented_test.go
+++ b/issuelink/unimplemented_test.go
@@ -75,26 +75,26 @@ func TestFormatUnimp(t *testing.T) {
 		{"unimp",
 			issuelink.UnimplementedError(link, "woo"),
 			woo, `
-woo:
-    (unimplemented error)
+woo
+- (*issuelink.unimplementedError:) woo
     issue: http://mysite`},
 		{"unimp-details",
 			issuelink.UnimplementedError(issuelink.IssueLink{IssueURL: "http://mysite", Detail: "see more"}, "woo"),
 			woo, `
-woo:
-    (unimplemented error)
+woo
+- (*issuelink.unimplementedError:) woo
     issue: http://mysite
     detail: see more`},
 
 		{"wrapper + unimp",
 			&werrFmt{issuelink.UnimplementedError(link, "woo"), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - woo:
-    (unimplemented error)
-    issue: http://mysite`},
+waa: woo
+- (*issuelink.unimplementedError:) woo
+    issue: http://mysite
+- (*issuelink_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload`},
 	}
 
 	for _, test := range testCases {
@@ -102,19 +102,19 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }

--- a/issuelink/with_issuelink.go
+++ b/issuelink/with_issuelink.go
@@ -66,7 +66,6 @@ func (w *withIssueLink) Format(s fmt.State, verb rune) { errbase.FormatError(w, 
 
 func (w *withIssueLink) FormatError(p errbase.Printer) error {
 	if p.Detail() {
-		p.Print("error with linked issue")
 		if w.IssueURL != "" {
 			p.Printf("\nissue: %s", w.IssueURL)
 		}

--- a/markers/markers.go
+++ b/markers/markers.go
@@ -197,7 +197,7 @@ func (m *withMark) Format(s fmt.State, verb rune) { errbase.FormatError(m, s, ve
 
 func (m *withMark) FormatError(p errbase.Printer) error {
 	if p.Detail() {
-		p.Printf("error with mark override:\n%q\n%s::%s",
+		p.Printf("%q\n%s::%s",
 			m.mark.msg,
 			m.mark.types[0].FamilyName,
 			m.mark.types[0].Extension,

--- a/markers/markers_test.go
+++ b/markers/markers_test.go
@@ -452,32 +452,35 @@ func TestFormat(t *testing.T) {
 		{"marked",
 			markers.Mark(goErr.New("woo"), refErr),
 			woo, `
-error with mark override:
+woo
+- (*errors.errorString:) woo
+- (*markers.withMark:)
     "foo"
-    errors/*errors.errorString::
-  - woo`},
+    errors/*errors.errorString::`},
 
 		{"marked + wrapper",
 			markers.Mark(&werrFmt{goErr.New("woo"), "waa"}, refErr),
 			waawoo, `
-error with mark override:
+waa: woo
+- (*errors.errorString:) woo
+- (*markers_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload
+- (*markers.withMark:)
     "foo"
-    errors/*errors.errorString::
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+    errors/*errors.errorString::`},
 
 		{"wrapper + marked",
 			&werrFmt{markers.Mark(goErr.New("woo"), refErr), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - error with mark override:
+waa: woo
+- (*errors.errorString:) woo
+- (*markers.withMark:)
     "foo"
     errors/*errors.errorString::
-  - woo`},
+- (*markers_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload`},
 	}
 
 	for _, test := range testCases {
@@ -485,19 +488,19 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -515,7 +518,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/safedetails/safedetails_test.go
+++ b/safedetails/safedetails_test.go
@@ -42,17 +42,16 @@ func TestDetailCapture(t *testing.T) {
 		tt.Check(markers.Is(err, origErr))
 
 		// The message is unchanged by the wrapper.
-		tt.CheckEqual(err.Error(), "hello world")
+		tt.CheckStringEqual(err.Error(), "hello world")
 
-		// The unsafe string is hidden.
+		// The detail strings are hidden.
 		errV := fmt.Sprintf("%+v", err)
 		tt.Check(!strings.Contains(errV, "and universe"))
+		tt.Check(!strings.Contains(errV, "planet"))
+		tt.Check(!strings.Contains(errV, "bye %s %s"))
 
-		// The safe string is preserved.
-		tt.Check(strings.Contains(errV, "planet"))
-
-		// The format string is preserved.
-		tt.Check(strings.Contains(errV, "bye %s %s"))
+		// The fact there are details is preserved.
+		tt.Check(strings.Contains(errV, "3 details enclosed"))
 	}
 
 	// Check the error properties locally.
@@ -80,25 +79,46 @@ func TestFormat(t *testing.T) {
 		err           error
 		expFmtSimple  string
 		expFmtVerbose string
+		details       string
 	}{
 		{"safe onearg",
 			safedetails.WithSafeDetails(baseErr, "a"),
 			woo, `
-error with embedded safe details: a
-  - woo`},
+woo
+- (*errors.errorString:) woo
+- (*safedetails.withSafeDetails:) 1 detail enclosed`,
+			// Payload
+			`payload 0
+(0) a
+payload 1
+(empty)
+`},
 
 		{"safe empty",
 			safedetails.WithSafeDetails(baseErr, ""),
 			woo, `
-safe detail wrapper with no details
-  - woo`},
+woo
+- (*errors.errorString:) woo
+- (*safedetails.withSafeDetails:) 1 detail enclosed`,
+			// Payload
+			`payload 0
+(empty)
+payload 1
+(empty)
+`},
 
 		{"safe nofmt+onearg",
 			safedetails.WithSafeDetails(baseErr, "", 123),
 			woo, `
-error with embedded safe details:
-    -- arg 1: <int>
-  - woo`},
+woo
+- (*errors.errorString:) woo
+- (*safedetails.withSafeDetails:) 2 details enclosed`,
+			// Payload
+			`payload 0
+(1) -- arg 1: <int>
+payload 1
+(empty)
+`},
 
 		{"safe err",
 			safedetails.WithSafeDetails(baseErr, "a %v",
@@ -108,62 +128,131 @@ error with embedded safe details:
 					Err:  os.ErrNotExist,
 				}),
 			woo, `
-error with embedded safe details: a %v
-    -- arg 1: *errors.errorString: file does not exist
-    wrapper: *os.PathError: open
-  - woo`},
+woo
+- (*errors.errorString:) woo
+- (*safedetails.withSafeDetails:) 2 details enclosed`,
+			// Payload
+			`payload 0
+(0) a %v
+(1) -- arg 1: *errors.errorString: file does not exist
+wrapper: *os.PathError: open
+payload 1
+(empty)
+`},
 
 		{"safe",
 			safedetails.WithSafeDetails(baseErr, "a %s %s", "b", safedetails.Safe("c")),
 			woo, `
-error with embedded safe details: a %s %s
-    -- arg 1: <string>
-    -- arg 2: c
-  - woo`},
+woo
+- (*errors.errorString:) woo
+- (*safedetails.withSafeDetails:) 3 details enclosed`,
+			// Payload
+			`payload 0
+(0) a %s %s
+(1) -- arg 1: <string>
+(2) -- arg 2: c
+payload 1
+(empty)
+`},
 
 		{"safe + wrapper",
 			safedetails.WithSafeDetails(&werrFmt{baseErr, "waa"}, "a %s %s", "b", safedetails.Safe("c")),
 			waawoo, `
-error with embedded safe details: a %s %s
-    -- arg 1: <string>
-    -- arg 2: c
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*safedetails_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload
+- (*safedetails.withSafeDetails:) 3 details enclosed`,
+			// Payload
+			`payload 0
+(0) a %s %s
+(1) -- arg 1: <string>
+(2) -- arg 2: c
+payload 1
+(empty)
+payload 2
+(empty)
+`},
 
 		{"wrapper + safe",
 			&werrFmt{safedetails.WithSafeDetails(baseErr, "a %s %s", "b", safedetails.Safe("c")), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - error with embedded safe details: a %s %s
-    -- arg 1: <string>
-    -- arg 2: c
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*safedetails.withSafeDetails:) 3 details enclosed
+- (*safedetails_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload`,
+			// Payload
+			`payload 0
+(empty)
+payload 1
+(0) a %s %s
+(1) -- arg 1: <string>
+(2) -- arg 2: c
+payload 2
+(empty)
+`},
 
 		{"safe with wrapped error",
 			safedetails.WithSafeDetails(baseErr, "a %v",
 				&werrFmt{errors.New("wuu"), "waa"}),
 			woo,
-			`error with embedded safe details: a %v
-    -- arg 1: <*errors.errorString>
-    wrapper: <*safedetails_test.werrFmt>
-  - woo`},
+			`
+woo
+- (*errors.errorString:) woo
+- (*safedetails.withSafeDetails:) 2 details enclosed`,
+			// Payload
+			`payload 0
+(0) a %v
+(1) -- arg 1: <*errors.errorString>
+wrapper: <*safedetails_test.werrFmt>
+payload 1
+(empty)
+`},
 
-		{"safe in safe",
+		{"safe + safe, stacked",
+			safedetails.WithSafeDetails(
+				safedetails.WithSafeDetails(baseErr, "hello %s", safedetails.Safe("world")),
+				"delicious %s", safedetails.Safe("coffee")),
+			woo,
+			`
+woo
+- (*errors.errorString:) woo
+- (*safedetails.withSafeDetails:) 2 details enclosed
+- (*safedetails.withSafeDetails:) 2 details enclosed`,
+			// Payload
+			`payload 0
+(0) delicious %s
+(1) -- arg 1: coffee
+payload 1
+(0) hello %s
+(1) -- arg 1: world
+payload 2
+(empty)
+`},
+
+		{"safe as arg to safe",
 			safedetails.WithSafeDetails(baseErr, "a %v",
 				safedetails.WithSafeDetails(errors.New("wuu"),
 					"b %v", safedetails.Safe("waa"))),
 			woo,
-			`error with embedded safe details: a %v
-    -- arg 1: <*errors.errorString>
-    wrapper: <*safedetails.withSafeDetails>
-    (more details:)
-    b %v
-    -- arg 1: waa
-  - woo`},
+			`
+woo
+- (*errors.errorString:) woo
+- (*safedetails.withSafeDetails:) 2 details enclosed`,
+			// Payload
+			`payload 0
+(0) a %v
+(1) -- arg 1: <*errors.errorString>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+b %v
+-- arg 1: waa
+payload 1
+(empty)
+`},
 	}
 
 	for _, test := range testCases {
@@ -171,19 +260,37 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
+
+			// Check the actual details produced.
+			details := errbase.GetAllSafeDetails(err)
+			var buf strings.Builder
+			for i, d := range details {
+				fmt.Fprintf(&buf, "payload %d\n", i)
+				if len(d.SafeDetails) == 0 || (len(d.SafeDetails) == 1 && d.SafeDetails[0] == "") {
+					fmt.Fprintf(&buf, "(empty)\n")
+					continue
+				}
+				for j, sd := range d.SafeDetails {
+					if len(sd) == 0 {
+						continue
+					}
+					fmt.Fprintf(&buf, "(%d) %s\n", j, sd)
+				}
+			}
+			tt.CheckStringEqual(buf.String(), test.details)
 		})
 	}
 }
@@ -201,7 +308,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/safedetails/with_safedetails.go
+++ b/safedetails/with_safedetails.go
@@ -33,25 +33,16 @@ func (e *withSafeDetails) SafeDetails() []string {
 }
 
 var _ fmt.Formatter = (*withSafeDetails)(nil)
-var _ errbase.Formatter = (*withSafeDetails)(nil)
 
 // Printing a withSecondary reveals the details.
 func (e *withSafeDetails) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
 
 func (e *withSafeDetails) FormatError(p errbase.Printer) error {
-	if p.Detail() {
-		if len(e.safeDetails) == 0 || (len(e.safeDetails) == 1 && e.safeDetails[0] == "") {
-			p.Print("safe detail wrapper with no details")
-		} else {
-			p.Print("error with embedded safe details:")
-			if e.safeDetails[0] != "" {
-				p.Printf(" %s", e.safeDetails[0])
-			}
-			for _, d := range e.safeDetails[1:] {
-				p.Printf("\n%s", d)
-			}
-		}
+	plural := "s"
+	if len(e.safeDetails) == 1 {
+		plural = ""
 	}
+	p.Printf("%d detail%s enclosed", len(e.safeDetails), plural)
 	return e.cause
 }
 

--- a/secondary/with_secondary.go
+++ b/secondary/with_secondary.go
@@ -50,8 +50,7 @@ func (e *withSecondaryError) Format(s fmt.State, verb rune) { errbase.FormatErro
 
 func (e *withSecondaryError) FormatError(p errbase.Printer) (next error) {
 	if p.Detail() {
-		p.Printf("combined error\nancillary error: %+v", e.secondaryError)
-		p.Print("\n(main error follows)")
+		p.Printf("ancillary error: %+v", e.secondaryError)
 	}
 	return e.cause
 }

--- a/telemetrykeys/telemetrykeys_test.go
+++ b/telemetrykeys/telemetrykeys_test.go
@@ -42,7 +42,7 @@ func TestTelemetry(t *testing.T) {
 		"hello")
 
 	tt.Check(markers.Is(err, baseErr))
-	tt.CheckEqual(err.Error(), "hello: world")
+	tt.CheckStringEqual(err.Error(), "hello: world")
 
 	keys := telemetrykeys.GetTelemetryKeys(err)
 	sort.Strings(keys)
@@ -56,7 +56,7 @@ func TestTelemetry(t *testing.T) {
 	newErr := errbase.DecodeError(context.Background(), enc)
 
 	tt.Check(markers.Is(newErr, baseErr))
-	tt.CheckEqual(newErr.Error(), "hello: world")
+	tt.CheckStringEqual(newErr.Error(), "hello: world")
 
 	keys = telemetrykeys.GetTelemetryKeys(newErr)
 	sort.Strings(keys)
@@ -82,26 +82,32 @@ func TestFormat(t *testing.T) {
 		{"keys",
 			telemetrykeys.WithTelemetry(baseErr, "a", "b"),
 			woo, `
-error with telemetry keys: [a b]
-  - woo`},
+woo
+- (*errors.errorString:) woo
+- (*telemetrykeys.withTelemetry:)
+    keys: [a b]`},
 
 		{"keys + wrapper",
 			telemetrykeys.WithTelemetry(&werrFmt{baseErr, "waa"}, "a", "b"),
 			waawoo, `
-error with telemetry keys: [a b]
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*telemetrykeys_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload
+- (*telemetrykeys.withTelemetry:)
+    keys: [a b]`},
 
 		{"wrapper + keys",
 			&werrFmt{telemetrykeys.WithTelemetry(baseErr, "a", "b"), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - error with telemetry keys: [a b]
-  - woo`},
+waa: woo
+- (*errors.errorString:) woo
+- (*telemetrykeys.withTelemetry:)
+    keys: [a b]
+- (*telemetrykeys_test.werrFmt:) waa
+    -- this is waa's
+    multi-line payload`},
 	}
 
 	for _, test := range testCases {
@@ -109,19 +115,19 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -139,7 +145,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/telemetrykeys/with_telemetry.go
+++ b/telemetrykeys/with_telemetry.go
@@ -42,7 +42,7 @@ func (w *withTelemetry) Format(s fmt.State, verb rune) { errbase.FormatError(w, 
 
 func (w *withTelemetry) FormatError(p errbase.Printer) (next error) {
 	if p.Detail() {
-		p.Printf("error with telemetry keys: %+v", w.keys)
+		p.Printf("keys: %+v", w.keys)
 	}
 	return w.cause
 }

--- a/testutils/simplecheck.go
+++ b/testutils/simplecheck.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 
@@ -123,6 +124,16 @@ func (t *T) CheckEqual(val, ref interface{}) {
 	if val != ref {
 		t.failWithf(false, "values not equal\n     got: %# v\nexpected: %# v",
 			pretty.Formatter(val), pretty.Formatter(ref))
+	}
+}
+
+// CheckEqual checks that the string value is equal to some reference.
+func (t *T) CheckStringEqual(val, ref string) {
+	t.Helper()
+	if val != ref {
+		t.failWithf(false, "values not equal; got:\n  %s\nexpected:\n  %s",
+			strings.ReplaceAll(val, "\n", "\n  "),
+			strings.ReplaceAll(ref, "\n", "\n  "))
 	}
 }
 

--- a/withstack/one_line_source.go
+++ b/withstack/one_line_source.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors/errbase"
-	pkgErr "github.com/pkg/errors"
 )
 
 // GetOneLineSource extracts the file/line/function information
@@ -40,7 +39,7 @@ func GetOneLineSource(err error) (file string, line int, fn string, ok bool) {
 
 	// If we have a stack trace in the style of github.com/pkg/errors
 	// (either from there or our own withStack), use it.
-	if st, ok := err.(interface{ StackTrace() pkgErr.StackTrace }); ok {
+	if st, ok := err.(errbase.StackTraceProvider); ok {
 		return getOneLineSourceFromPkgStack(st.StackTrace())
 	}
 
@@ -62,7 +61,7 @@ func GetOneLineSource(err error) (file string, line int, fn string, ok bool) {
 }
 
 func getOneLineSourceFromPkgStack(
-	st pkgErr.StackTrace,
+	st errbase.StackTrace,
 ) (file string, line int, fn string, ok bool) {
 	if len(st) > 0 {
 		st = st[:1]

--- a/withstack/reportable.go
+++ b/withstack/reportable.go
@@ -46,7 +46,7 @@ type ReportableStackTrace = sentry.Stacktrace
 func GetReportableStackTrace(err error) *ReportableStackTrace {
 	// If we have a stack trace in the style of github.com/pkg/errors
 	// (either from there or our own withStack), use it.
-	if st, ok := err.(interface{ StackTrace() pkgErr.StackTrace }); ok {
+	if st, ok := err.(errbase.StackTraceProvider); ok {
 		return convertPkgStack(st.StackTrace())
 	}
 
@@ -71,7 +71,7 @@ type frame = sentry.Frame
 
 // convertPkgStack converts a StackTrace from github.com/pkg/errors
 // to a Stacktrace in github.com/getsentry/sentry-go.
-func convertPkgStack(st pkgErr.StackTrace) *ReportableStackTrace {
+func convertPkgStack(st errbase.StackTrace) *ReportableStackTrace {
 	// If there are no frames, the entire stacktrace is nil.
 	if len(st) == 0 {
 		return nil

--- a/withstack/stack.go
+++ b/withstack/stack.go
@@ -18,16 +18,8 @@ import (
 	"fmt"
 	"runtime"
 
-	pkgErr "github.com/pkg/errors"
+	"github.com/cockroachdb/errors/errbase"
 )
-
-// StackTrace is the type of the data for a call stack.
-// This mirrors the type of the same name in github.com/pkg/errors.
-type StackTrace = pkgErr.StackTrace
-
-// Frame is the type of a single call frame entry.
-// This mirrors the type of the same name in github.com/pkg/errors.
-type Frame = pkgErr.Frame
 
 // stack represents a stack of program counters.
 // This mirrors the (non-exported) type of the same name in github.com/pkg/errors.
@@ -40,7 +32,7 @@ func (s *stack) Format(st fmt.State, verb rune) {
 		switch {
 		case st.Flag('+'):
 			for _, pc := range *s {
-				f := Frame(pc)
+				f := errbase.StackFrame(pc)
 				fmt.Fprintf(st, "\n%+v", f)
 			}
 		}
@@ -48,10 +40,10 @@ func (s *stack) Format(st fmt.State, verb rune) {
 }
 
 // StackTrace mirrors the code in github.com/pkg/errors.
-func (s *stack) StackTrace() StackTrace {
-	f := make([]Frame, len(*s))
+func (s *stack) StackTrace() errbase.StackTrace {
+	f := make([]errbase.StackFrame, len(*s))
 	for i := 0; i < len(f); i++ {
-		f[i] = Frame((*s)[i])
+		f[i] = errbase.StackFrame((*s)[i])
 	}
 	return f
 }

--- a/withstack/withstack.go
+++ b/withstack/withstack.go
@@ -58,21 +58,17 @@ type withStack struct {
 
 var _ error = (*withStack)(nil)
 var _ fmt.Formatter = (*withStack)(nil)
-var _ errbase.Formatter = (*withStack)(nil)
 var _ errbase.SafeDetailer = (*withStack)(nil)
 
 func (w *withStack) Error() string { return w.cause.Error() }
 func (w *withStack) Cause() error  { return w.cause }
 func (w *withStack) Unwrap() error { return w.cause }
 
+// Format implements the fmt.Formatter interface.
+//
+// Note: withStack does *not* implement errbase.Formatter, as printing
+// out the stack trace is already done by FormatError().
 func (w *withStack) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
-
-func (w *withStack) FormatError(p errbase.Printer) error {
-	if p.Detail() {
-		p.Printf("error with attached stack trace:%+v", w.stack)
-	}
-	return w.cause
-}
 
 func (w *withStack) SafeDetails() []string {
 	return []string{fmt.Sprintf("%+v", w.StackTrace())}


### PR DESCRIPTION
The previous code was erring towards maximizing code and interface
reuse from the `xerrors` package. That was done prior to the release
of Go 1.13, back when all the formatting principles of `xerrors` were
planned for inclusion in Go 1.13.

Then Go 1.13 was released and the formatting code in `xerrors` was
trashed withouyt making it to Go 1.13: it was imperfect.

Among the imperfections:

- it was printing errors from outermost layer to innermost.
  This is counter-intuitive: during troubleshooting the most
  relevant information is at the innermost level.
- it was peeling the message strings bit by bit.
  This is confusing: the full text of the error (as would be
  printed by `%s` / `.Error()`) had to be re-constructed manually.
- it had a complex integration with its `Printer` interface, due to the
  complex interplay between the `Detail()` method and the `Print()`
  methods.

These problems alone were large enough (and really impeding
productivity) to motivate a redesign.

Additionally, experience with this `errors` library revealed the
following additional imperfections:

- when an error object travels through application layers, it collects
  multiple stack traces. Printing every stack trace in full results in
  large amounts of redundant information. In fact, in the common case
  the stack trace in an outer layer of wrapping is a suffix of the stack
  trace(s) in the inner layers.
- the intermediate layers of "safe details" are, by design,
  repeating the "safe" (redacted) subset of information available
  in other parts of an error stack. While the *existence* of
  such a layer may be relevant, there is no need to display
  its contents with `%+v` - it does not add anything that
  the remainder of the error doesn't already reveal.
- the hidden cause behind a barrier error, if it was not provided
  by this library, would not be displayed with details
  when printed with `%+v`.

This patch follows up on these various observations by changing
`errors.FormatError` used for `%+v` formatting as follows:

- it prints out the full text of the error (as per `.Error()`) on
  the first line of output.
- it changes the printing order of details to print from innermost
  to outermost.
- it elides repeated entries in displayed stack traces.
- it omits the details contained in "safe details" layers.
- it properly reveals the structure of the hidden cause of
  barrier errors.

Additionally, it now prints out the Go type of the error layers on
each line of details. This has two purposes:

- it eases the troubleshooting of faulty error type comparisons or
  tests using `errors.Is` / `errors.As`.
- it makes it possible to reduce the verbosity of the
  output when printing errors with similarly structured
  payload, e.g. issue links and unimplemented errors.

This change also implies that `%+v` no longers reveals _all_ the
details of an error chain. This is deemed acceptable: these details
can be revealed otherwise by using e.g. `pretty.Formatter()` from
package `github.com/kr/pretty`.

Here is an example. Consider the following Go code:
```go
	err := errors.New("coffee")
	err = errors.Wrap(err, "delicious")
	err = errors.NewAssertionErrorWithWrappedErrf(err, "bitter")
	fmt.Printf("%+v\n", err)
```

Before this patch:
```
assertion failure
  - error with attached stack trace:
    main.main
        /data/home/kena/src/go/src/github.com/cockroachdb/cockroach/t/test.go:12
    runtime.main
        /usr/local/go/src/runtime/proc.go:203
    runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1357
  - error with embedded safe details: bitter
  - bitter:
  - delicious: coffee:
    original cause behind barrier: error with attached stack trace:
        main.main
                /data/home/kena/src/go/src/github.com/cockroachdb/cockroach/t/test.go:11
        runtime.main
                /usr/local/go/src/runtime/proc.go:203
        runtime.goexit
                /usr/local/go/src/runtime/asm_amd64.s:1357
      - delicious:
      - error with attached stack trace:
        main.main
                /data/home/kena/src/go/src/github.com/cockroachdb/cockroach/t/test.go:10
        runtime.main
                /usr/local/go/src/runtime/proc.go:203
        runtime.goexit
                /usr/local/go/src/runtime/asm_amd64.s:1357
      - coffee
```

Notice the defects:
- the components are printed from least to most relevant.
- the words of the message ("bitter", "delicious", "coffee") are
  far apart.
- the stack trace is repeated three times.
- the safe detail part repeats a word that's already there.

After this patch:
```
bitter: delicious: coffee
- (*barriers.barrierError:) delicious: coffee
    hidden cause: delicious: coffee
    - (*errors.errorString:) coffee
    - (*withstack.withStack:)
        main.main
                /data/home/kena/src/t/test.go:10
        runtime.main
                /usr/local/go/src/runtime/proc.go:203
        runtime.goexit
                /usr/local/go/src/runtime/asm_amd64.s:1357
    - (*errutil.withMessage:) delicious
    - (*withstack.withStack:)
        main.main
                /data/home/kena/src/t/test.go:11
        [...same entries as above...]
- (*errutil.withMessage:) bitter
- (*safedetails.withSafeDetails:) 1 detail enclosed
- (*withstack.withStack:)
    main.main
        /data/home/kena/src/t/test.go:12
    runtime.main
        /usr/local/go/src/runtime/proc.go:203
    runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1357
- (*assert.withAssertionFailure:)
```

- the complete message is emitted at the top.
- the ordering is clearer.
- the types are spelled out, which eases understanding type
  comparisons and error marks.
- the safe details are omitted
- the stack traces are reduced.
  (Note: the stack trace out of a barrier cannot
  be reduced using the info from "inside" the barrier
  because what's inside the barrier is hidden to the
  outside formatter.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/25)
<!-- Reviewable:end -->
