### PR TITLE
Re-vamp the infrastructure for `%+v` formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ older version of the package.
 |-----------------------------------------------------------------|-------------------------------------|--------------|-------------------------------|-----------------------------------|
 | main message, eg `New()`                                        | visible                             | visible      | redacted                      | redacted                          |
 | wrap prefix, eg `WithMessage()`                                 | visible (as prefix)                 | visible      | redacted                      | redacted                          |
-| stack trace, eg `WithStack()`                                   | not visible                         | visible      | yes                           | full                              |
+| stack trace, eg `WithStack()`                                   | not visible                         | simplified   | yes                           | full                              |
 | hint , eg `WithHint()`                                          | not visible                         | visible      | no                            | type only                         |
 | detail, eg `WithDetail()`                                       | not visible                         | visible      | no                            | type only                         |
 | assertion failure annotation, eg `WithAssertionFailure()`       | not visible                         | visible      | no                            | type only                         |
 | issue links, eg `WithIssueLink()`, `UnimplementedError()`       | not visible                         | visible      | yes                           | full                              |
-| safe details, eg `WithSafeDetails()`                            | not visible                         | visible      | yes                           | full                              |
+| safe details, eg `WithSafeDetails()`                            | not visible                         | not visible  | yes                           | full                              |
 | telemetry keys, eg. `WithTelemetryKey()`                        | not visible                         | visible      | yes                           | full                              |
 | secondary errors, eg. `WithSecondaryError()`, `CombineErrors()` | not visible                         | visible      | redacted, recursively         | redacted, recursively             |
 | barrier origins, eg. `Handled()`                                | not visible                         | visible      | redacted, recursively         | redacted, recursively             |

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -78,9 +78,7 @@ func (w *withAssertionFailure) Unwrap() error { return w.cause }
 
 func (w *withAssertionFailure) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 func (w *withAssertionFailure) FormatError(p errbase.Printer) error {
-	if p.Detail() {
-		p.Print("assertion failure")
-	}
+	p.Print("assertion failure")
 	return w.cause
 }
 

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -73,26 +73,32 @@ func TestFormat(t *testing.T) {
 		{"assert",
 			assert.WithAssertionFailure(baseErr),
 			woo, `
-assertion failure
-  - woo`},
+woo
+(1) assertion failure
+Wraps: (2) woo
+Error types: (1) *assert.withAssertionFailure (2) *errors.errorString`},
 
 		{"assert + wrapper",
 			assert.WithAssertionFailure(&werrFmt{baseErr, "waa"}),
 			waawoo, `
-assertion failure
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+waa: woo
+(1) assertion failure
+Wraps: (2) waa
+  | -- this is waa's
+  | multi-line payload
+Wraps: (3) woo
+Error types: (1) *assert.withAssertionFailure (2) *assert_test.werrFmt (3) *errors.errorString`},
 
 		{"wrapper + assert",
 			&werrFmt{assert.WithAssertionFailure(baseErr), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - assertion failure
-  - woo`},
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line payload
+Wraps: (2) assertion failure
+Wraps: (3) woo
+Error types: (1) *assert_test.werrFmt (2) *assert.withAssertionFailure (3) *errors.errorString`},
 	}
 
 	for _, test := range testCases {
@@ -100,19 +106,19 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -130,7 +136,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/barriers/barriers.go
+++ b/barriers/barriers.go
@@ -95,9 +95,9 @@ func (e *barrierError) SafeDetails() []string {
 func (e *barrierError) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
 
 func (e *barrierError) FormatError(p errbase.Printer) (next error) {
-	p.Print(e.msg)
+	p.Printf(e.msg)
 	if p.Detail() {
-		p.Printf("\noriginal cause behind barrier: %+v", e.maskedErr)
+		p.Printf("-- cause hidden behind barrier\n%+v", e.maskedErr)
 	}
 	return nil
 }

--- a/contexttags/with_context.go
+++ b/contexttags/with_context.go
@@ -53,8 +53,8 @@ func (w *withContext) Unwrap() error { return w.cause }
 func (w *withContext) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withContext) FormatError(p errbase.Printer) error {
-	if p.Detail() && w.tags != nil {
-		p.Printf("error with context tags: %s", w.tags.String())
+	if w.tags != nil {
+		p.Printf("tags: [%s]", w.tags.String())
 	}
 	return w.cause
 }

--- a/domains/domains_test.go
+++ b/domains/domains_test.go
@@ -191,26 +191,32 @@ func TestFormat(t *testing.T) {
 		{"keys",
 			domains.WithDomain(baseErr, domains.NoDomain),
 			woo, `
-error domain: <none>
-  - woo`},
+woo
+(1) error domain: <none>
+Wraps: (2) woo
+Error types: (1) *domains.withDomain (2) *errors.errorString`},
 
 		{"keys + wrapper",
 			domains.WithDomain(&werrFmt{baseErr, "waa"}, domains.NoDomain),
 			waawoo, `
-error domain: <none>
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+waa: woo
+(1) error domain: <none>
+Wraps: (2) waa
+  | -- this is waa's
+  | multi-line payload
+Wraps: (3) woo
+Error types: (1) *domains.withDomain (2) *domains_test.werrFmt (3) *errors.errorString`},
 
 		{"wrapper + keys",
 			&werrFmt{domains.WithDomain(baseErr, domains.NoDomain), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - error domain: <none>
-  - woo`},
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line payload
+Wraps: (2) error domain: <none>
+Wraps: (3) woo
+Error types: (1) *domains_test.werrFmt (2) *domains.withDomain (3) *errors.errorString`},
 	}
 
 	for _, test := range testCases {
@@ -218,19 +224,19 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -248,7 +254,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/domains/with_domain.go
+++ b/domains/with_domain.go
@@ -59,9 +59,7 @@ func (e *withDomain) SafeDetails() []string {
 func (e *withDomain) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
 
 func (e *withDomain) FormatError(p errbase.Printer) error {
-	if p.Detail() {
-		p.Print(e.domain)
-	}
+	p.Print(e.domain)
 	return e.cause
 }
 

--- a/errbase/format_error.go
+++ b/errbase/format_error.go
@@ -29,6 +29,8 @@ import (
 	"io"
 	"reflect"
 	"strconv"
+
+	pkgErr "github.com/pkg/errors"
 )
 
 // FormatError formats an error according to s and verb.
@@ -48,37 +50,48 @@ func FormatError(err error, s fmt.State, verb rune) {
 	// disregard that State may be a specific printer implementation and use one
 	// of our choice instead.
 
-	// limitations: does not support printing error as Go struct.
+	p := state{State: s}
 
-	var (
-		sep    = " " // separator before next error
-		p      = &state{State: s}
-		direct = true
-	)
+	switch {
+	case verb == 'v' && s.Flag('+'):
+		// Here we are going to format as per %+v, into p.buf.
+		//
+		// We need to start with the innermost (root cause) error first,
+		// then the layers of wrapping from innermost to outermost, so as
+		// to enable stack trace de-duplication. This requires a
+		// post-order traversal. Since we have a linked list, the best we
+		// can do is a recursion.
+		p.formatRecursive(err, true /* isOutermost */)
 
-	switch verb {
-	// Note that this switch must match the preference order
-	// for ordinary string printing (%#v before %+v, and so on).
+		// We now have all the data, we can render the result.
+		p.formatEntries(err)
 
-	case 'v':
-		if s.Flag('#') {
-			if stringer, ok := err.(fmt.GoStringer); ok {
-				io.WriteString(&p.buf, stringer.GoString())
-				goto exit
-			}
-			// proceed as if it were %v
-		} else if s.Flag('+') {
-			p.printDetail = true
-			sep = "\n  - "
+		// We're done formatting. Apply width/precision parameters.
+		p.finishDisplay(verb)
+
+	case verb == 'v' && s.Flag('#'):
+		if stringer, ok := err.(fmt.GoStringer); ok {
+			io.WriteString(&p.buf, stringer.GoString())
+			p.finishDisplay(verb)
+			return
 		}
-	case 's':
-	case 'q', 'x', 'X':
-		// Use an intermediate buffer in the rare cases that precision,
-		// truncation, or one of the alternative verbs (q, x, and X) are
-		// specified.
-		direct = false
+		// Not a stringer. Proceed as if it were %v.
+		fallthrough
+
+	case verb == 's' || verb == 'q' ||
+		verb == 'x' || verb == 'X' || verb == 'v':
+		// Only the error message.
+		//
+		// Use an intermediate buffer because there may be alignment
+		// instructions to obey in the final rendering or
+		// quotes to add (for %q).
+		//
+		p.buf.WriteString(err.Error())
+		p.finishDisplay(verb)
 
 	default:
+		// Unknown verb. Do like fmt.Printf and tell the user we're
+		// confused.
 		p.buf.WriteString("%!")
 		p.buf.WriteRune(verb)
 		p.buf.WriteByte('(')
@@ -90,94 +103,149 @@ func FormatError(err error, s fmt.State, verb rune) {
 		}
 		p.buf.WriteByte(')')
 		io.Copy(s, &p.buf)
-		return
+	}
+}
+
+func needSpaceAtBeginning(buf []byte) bool {
+	return len(buf) > 0 && buf[0] != '\n'
+}
+
+func (s *state) formatEntries(err error) {
+	// The first entry at the top is special. We format it as follows:
+	//
+	//   <complete error message>
+	//   (1) <details>
+	s.buf.WriteString(err.Error())
+	s.buf.WriteString("\n(1)")
+	firstEntry := s.entries[len(s.entries)-1].buf
+	if needSpaceAtBeginning(firstEntry) {
+		s.buf.WriteByte(' ')
+	}
+	s.buf.Write(firstEntry)
+
+	// All the entries that follow are printed as follows:
+	//
+	// Wraps: (N) <details>
+	//
+	for i, j := len(s.entries)-2, 2; i >= 0; i, j = i-1, j+1 {
+		fmt.Fprintf(&s.buf, "\nWraps: (%d)", j)
+		thisEntry := s.entries[i].buf
+		if needSpaceAtBeginning(thisEntry) {
+			s.buf.WriteByte(' ')
+		}
+		s.buf.Write(thisEntry)
 	}
 
-	// CHANGE (cockroachdb/errors): FormatError() accepts `error` and
-	// not `Formatter` as first argument, and uses a separate path when
-	// the object does not implement `Formatter`. This makes it possible
-	// to start implementing a wrapper with just a `Format()` method
-	// that forwards to `FormatError()`, without implementing
-	// `errors.Formatter` just yet.
-	if _, ok := err.(Formatter); !ok {
-		// formatSimpleError prints Error() or, if a wrapper, the
-		// error prefix then recurses FormatError() on the causes.
-		err = formatSimpleError(err, p, sep)
+	// At the end, we link all the (N) references to the Go type of the
+	// error.
+	s.buf.WriteString("\nError types:")
+	for i, j := len(s.entries)-1, 1; i >= 0; i, j = i-1, j+1 {
+		fmt.Fprintf(&s.buf, " (%d) %T", j, s.entries[i].err)
 	}
-	// if formatSimpleError() has taken over, skip the loop.
-	if err == nil {
-		goto exit
+}
+
+// formatRecursive performs a post-order traversal to
+// prints errors from innermost to outermost.
+func (s *state) formatRecursive(err error, isOutermost bool) {
+	cause := UnwrapOnce(err)
+	if cause != nil {
+		// Recurse first.
+		s.formatRecursive(cause, false /*isOutermost*/)
 	}
 
-loop:
-	for {
-		// CHANGE (cockroachdb/errors): we only emit the inter-error
-		// separator if something was printed since the last error.
-		// This way, an error of the form err1 -> err2 -> err3 will
-		// properly print as "err1: err3" if err2 has no message.
-		// In the original code, this would have been (incorrectly)
-		// rendered as "err1: : err3".
-		prevLen := p.buf.Len()
+	s.needSpace = false
+	s.needNewline = 0
+	s.multiLine = false
+	s.notEmpty = false
 
-		switch v := err.(type) {
-		case Formatter:
-			err = v.FormatError((*printer)(p))
-		case fmt.Formatter:
-			v.Format(p, 'v')
-			break loop
-		default:
-			// CHANGE (cockroachdb/errors): if the error did not
-			// implement errors.Formatter nor fmt.Formatter, but it is a wrapper,
-			// still attempt best effort: print what we can at this level, then
-			// recurse to give a chance to the cause to self-format
-			// properly.
-			if cause := UnwrapOnce(err); cause != nil {
-				pref := extractPrefix(err, cause)
-				p.buf.WriteString(pref)
-				err = cause
-			} else {
-				io.WriteString(&p.buf, v.Error())
-				break loop
+	seenTrace := false
+
+	switch v := err.(type) {
+	case Formatter:
+		_ = v.FormatError((*printer)(s))
+	case fmt.Formatter:
+		// We can only use a fmt.Formatter when both the following
+		// conditions are true:
+		// - when it is the leaf error, because a fmt.Formatter
+		//   on a wrapper also recurses.
+		// - when it is not the outermost wrapper, because
+		//   the Format() method is likely to be calling FormatError()
+		//   to do its job and we want to avoid an infinite recursion.
+		if !isOutermost && cause == nil {
+			v.Format(s, 'v')
+			if st, ok := err.(StackTraceProvider); ok {
+				// This is likely a leaf error from github/pkg/errors.
+				// The thing probably printed its stack trace on its own.
+				seenTrace = true
+				// We'll subsequently simplify stack traces in wrappers.
+				s.lastStack = st.StackTrace()
+			}
+		} else {
+			s.formatSimple(err, cause)
+		}
+	default:
+		// If the error did not implement errors.Formatter nor
+		// fmt.Formatter, but it is a wrapper, still attempt best effort:
+		// print what we can at this level.
+		s.formatSimple(err, cause)
+	}
+
+	// If there's an embedded stack trace, print it.
+	// This will get either a stack from pkg/errors, or ours.
+	if !seenTrace {
+		if st, ok := err.(StackTraceProvider); ok {
+			if s.multiLine {
+				s.Write([]byte("\n-- stack trace:"))
+			}
+			newStack, elided := ElideSharedStackTraceSuffix(s.lastStack, st.StackTrace())
+			s.lastStack = newStack
+			newStack.Format(s, 'v')
+			if elided {
+				s.Write([]byte("\n[...repeated from below...]"))
 			}
 		}
-
-		if err == nil {
-			break
-		}
-
-		// CHANGE (cockroachdb/errors): if there was nothing printed
-		// for this intermediate error, skip printing the separator.
-		skipSep := p.buf.Len() == prevLen
-		if !skipSep {
-			if p.needColon || !p.printDetail {
-				p.buf.WriteByte(':')
-			}
-			p.buf.WriteString(sep)
-		}
-
-		p.inDetail = false
-		p.needNewline = false
-		p.needColon = false
 	}
 
-	///////////////////////////////////////////////////////////////////////////////
-	// cockroachdb/errors: the remainder of the file is unchanged from the
-	// original code in xerrors.
+	s.entries = append(s.entries, formatEntry{err: err, buf: s.buf.Bytes()})
+	s.buf = bytes.Buffer{}
+}
 
-exit:
-	width, okW := s.Width()
-	prec, okP := s.Precision()
+func (s *state) formatSimple(err, cause error) {
+	var pref string
+	if cause != nil {
+		pref = extractPrefix(err, cause)
+	} else {
+		pref = err.Error()
+	}
+	if len(pref) > 0 {
+		s.Write([]byte(pref))
+	}
+}
+
+// finishDisplay renders the buffer in state into the fmt.State.
+func (p *state) finishDisplay(verb rune) {
+	width, okW := p.Width()
+	prec, okP := p.Precision()
+
+	// If `direct` is set to false, then the buffer is always
+	// passed through fmt.Printf regardless of the width and alignment
+	// settings. This is important or e.g. %q where quotes must be added
+	// in any case.
+	// If `direct` is set to true, then the detour via
+	// fmt.Printf only occurs if there is a width or alignment
+	// specifier.
+	direct := verb == 'v' || verb == 's'
 
 	if !direct || (okW && width > 0) || okP {
 		// Construct format string from State s.
 		format := []byte{'%'}
-		if s.Flag('-') {
+		if p.Flag('-') {
 			format = append(format, '-')
 		}
-		if s.Flag('+') {
+		if p.Flag('+') {
 			format = append(format, '+')
 		}
-		if s.Flag(' ') {
+		if p.Flag(' ') {
 			format = append(format, ' ')
 		}
 		if okW {
@@ -188,78 +256,137 @@ exit:
 			format = strconv.AppendInt(format, int64(prec), 10)
 		}
 		format = append(format, string(verb)...)
-		fmt.Fprintf(s, string(format), p.buf.String())
+		fmt.Fprintf(p.State, string(format), p.buf.String())
 	} else {
-		io.Copy(s, &p.buf)
+		io.Copy(p.State, &p.buf)
 	}
 }
 
-var detailSep = []byte("\n    ")
+var detailSep = []byte("\n  | ")
 
 // state tracks error printing state. It implements fmt.State.
 type state struct {
 	fmt.State
-	buf bytes.Buffer
+	buf     bytes.Buffer
+	entries []formatEntry
 
-	printDetail bool
-	inDetail    bool
-	needColon   bool
-	needNewline bool
+	lastStack   StackTrace
+	notEmpty    bool
+	needSpace   bool
+	needNewline int
+	multiLine   bool
+}
+
+type formatEntry struct {
+	err error
+	buf []byte
 }
 
 func (s *state) Write(b []byte) (n int, err error) {
-	if s.printDetail {
-		if len(b) == 0 {
-			return 0, nil
-		}
-		if s.inDetail && s.needColon {
-			s.needNewline = true
-			if b[0] == '\n' {
-				b = b[1:]
-			}
-		}
-		k := 0
-		for i, c := range b {
-			if s.needNewline {
-				if s.inDetail && s.needColon {
-					s.buf.WriteByte(':')
-					s.needColon = false
+	if len(b) == 0 {
+		return 0, nil
+	}
+	k := 0
+	for i, c := range b {
+		if c == '\n' {
+			s.buf.Write(b[k:i])
+			k = i + 1
+			s.needNewline++
+			s.needSpace = false
+			s.multiLine = true
+		} else {
+			if s.needNewline > 0 && s.notEmpty {
+				for i := 0; i < s.needNewline-1; i++ {
+					s.buf.Write(detailSep[:len(detailSep)-1])
 				}
 				s.buf.Write(detailSep)
-				s.needNewline = false
+				s.needNewline = 0
+				s.needSpace = false
+			} else if s.needSpace {
+				s.buf.WriteByte(' ')
+				s.needSpace = false
 			}
-			if c == '\n' {
-				s.buf.Write(b[k:i])
-				k = i + 1
-				s.needNewline = true
-			}
+			s.notEmpty = true
 		}
-		s.buf.Write(b[k:])
-		if !s.inDetail {
-			s.needColon = true
-		}
-	} else if !s.inDetail {
-		s.buf.Write(b)
 	}
+	s.buf.Write(b[k:])
 	return len(b), nil
 }
 
 // printer wraps a state to implement an xerrors.Printer.
 type printer state
 
+func (s *printer) Detail() bool {
+	s.needNewline = 1
+	s.notEmpty = false
+	return true
+}
+
 func (s *printer) Print(args ...interface{}) {
-	if !s.inDetail || s.printDetail {
-		fmt.Fprint((*state)(s), args...)
-	}
+	s.enhanceArgs(args)
+	fmt.Fprint((*state)(s), args...)
 }
 
 func (s *printer) Printf(format string, args ...interface{}) {
-	if !s.inDetail || s.printDetail {
-		fmt.Fprintf((*state)(s), format, args...)
-	}
+	s.enhanceArgs(args)
+	fmt.Fprintf((*state)(s), format, args...)
 }
 
-func (s *printer) Detail() bool {
-	s.inDetail = true
-	return s.printDetail
+func (s *printer) enhanceArgs(args []interface{}) {
+	prevStack := s.lastStack
+	lastSeen := prevStack
+	for i := range args {
+		if st, ok := args[i].(pkgErr.StackTrace); ok {
+			args[i], _ = ElideSharedStackTraceSuffix(prevStack, st)
+			lastSeen = st
+		}
+		if err, ok := args[i].(error); ok {
+			args[i] = &errorFormatter{err}
+		}
+	}
+	s.lastStack = lastSeen
+}
+
+type errorFormatter struct{ err error }
+
+// Format implements the fmt.Formatter interface.
+func (ef *errorFormatter) Format(s fmt.State, verb rune) { FormatError(ef.err, s, verb) }
+
+// ElideSharedStackTraceSuffix removes the suffix of newStack that's already
+// present in prevStack. The function returns true if some entries
+// were elided.
+func ElideSharedStackTraceSuffix(prevStack, newStack StackTrace) (StackTrace, bool) {
+	if len(prevStack) == 0 {
+		return newStack, false
+	}
+	if len(newStack) == 0 {
+		return newStack, false
+	}
+
+	// Skip over the common suffix.
+	var i, j int
+	for i, j = len(newStack)-1, len(prevStack)-1; i > 0 && j > 0; i, j = i-1, j-1 {
+		if newStack[i] != prevStack[j] {
+			break
+		}
+	}
+	if i == 0 {
+		// Keep at least one entry.
+		i = 1
+	}
+	return newStack[:i], i < len(newStack)-1
+}
+
+// StackTrace is the type of the data for a call stack.
+// This mirrors the type of the same name in github.com/pkg/errors.
+type StackTrace = pkgErr.StackTrace
+
+// StackFrame is the type of a single call frame entry.
+// This mirrors the type of the same name in github.com/pkg/errors.
+type StackFrame = pkgErr.Frame
+
+// StackTraceProvider is a provider of StackTraces.
+// This is, intendedly, defined to be implemented by pkg/errors.stack.
+type StackTraceProvider interface {
+	StackTrace() StackTrace
 }

--- a/errbase/format_error_test.go
+++ b/errbase/format_error_test.go
@@ -27,6 +27,83 @@ import (
 	pkgErr "github.com/pkg/errors"
 )
 
+func TestSimplifyStacks(t *testing.T) {
+	leaf := func() error {
+		return pkgErr.New("hello world")
+	}
+	wrapper := func() error {
+		err := leaf()
+		return pkgErr.WithStack(err)
+	}
+	errWrapper := wrapper()
+	t.Logf("error: %+v", errWrapper)
+
+	t.Run("low level API", func(t *testing.T) {
+		tt := testutils.T{t}
+		// Extract the stack trace from the leaf.
+		errLeaf := errbase.UnwrapOnce(errWrapper)
+		leafP, ok := errLeaf.(errbase.StackTraceProvider)
+		if !ok {
+			t.Fatal("leaf error does not provide stack trace")
+		}
+		leafT := leafP.StackTrace()
+		spv := fmtClean(leafT)
+		t.Logf("-- leaf trace --%+v", spv)
+		if !strings.Contains(spv, "TestSimplifyStacks") {
+			t.Fatalf("expected test function in trace, got:%v", spv)
+		}
+		leafLines := strings.Split(spv, "\n")
+
+		// Extract the stack trace from the wrapper.
+		wrapperP, ok := errWrapper.(errbase.StackTraceProvider)
+		if !ok {
+			t.Fatal("wrapper error does not provide stack trace")
+		}
+		wrapperT := wrapperP.StackTrace()
+		spv = fmtClean(wrapperT)
+		t.Logf("-- wrapper trace --%+v", spv)
+		wrapperLines := strings.Split(spv, "\n")
+
+		// Sanity check before we verify the result.
+		tt.Check(len(wrapperLines) > 0)
+		tt.CheckDeepEqual(wrapperLines[3:], leafLines[5:])
+
+		// Elide the suffix and verify that we arrive to the same result.
+		simplified, hasElided := errbase.ElideSharedStackTraceSuffix(leafT, wrapperT)
+		spv = fmtClean(simplified)
+		t.Logf("-- simplified (%v) --%+v", hasElided, spv)
+		simplifiedLines := strings.Split(spv, "\n")
+		tt.CheckDeepEqual(simplifiedLines, wrapperLines[0:3])
+	})
+
+	t.Run("high level API", func(t *testing.T) {
+		tt := testutils.T{t}
+
+		spv := fmtClean(&errFormatter{errWrapper})
+		tt.CheckStringEqual(spv, `hello world
+(1)
+  | github.com/cockroachdb/errors/errbase_test.TestSimplifyStacks.func2
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) hello world
+  | github.com/cockroachdb/errors/errbase_test.TestSimplifyStacks.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/errbase_test.TestSimplifyStacks.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/errbase_test.TestSimplifyStacks
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errors.withStack (2) *errors.fundamental`)
+	})
+}
+
+type errFormatter struct{ err error }
+
+func (f *errFormatter) Format(s fmt.State, verb rune) { errbase.FormatError(f.err, s, verb) }
+
 func TestFormat(t *testing.T) {
 	tt := testutils.T{t}
 
@@ -52,21 +129,26 @@ func TestFormat(t *testing.T) {
 			&errFmto{"woo"},
 			woo, `
 woo
--- verbose leaf (fmt):
-woo`, ``,
+-- this is woo's
+multi-line payload`, ``,
 		},
 
 		{"fmt-partial leaf",
 			&errFmtp{"woo"},
-			woo, woo, ``,
+			woo, `
+woo
+(1) woo
+Error types: (1) *errbase_test.errFmtp`, ``,
 		},
 
 		{"fmt leaf",
 			&errFmt{"woo"},
 			woo, `
-woo:
-    -- verbose leaf:
-    woo`, ``,
+woo
+(1) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.errFmt`, ``,
 		},
 
 		{"nofmt leaf + nofmt wrap",
@@ -77,24 +159,28 @@ woo:
 			&werrFmto{&errNoFmt{"woo"}, "waa"},
 			waawoo, `
 woo
--- verbose wrapper (fmt):
-waa`, ``,
+-- this is waa's
+multi-line payload (fmt)`, ``,
 		},
 
 		{"nofmt leaf + fmt-partial wrap",
 			&werrFmtp{&errNoFmt{"woo"}, "waa"},
 			waawoo, `
-waa:
-  - woo`, ``,
+waa: woo
+(1) waa
+Wraps: (2) woo
+Error types: (1) *errbase_test.werrFmtp (2) *errbase_test.errNoFmt`, ``,
 		},
 
 		{"nofmt leaf + fmt wrap",
 			&werrFmt{&errNoFmt{"woo"}, "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - woo`, ``,
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line wrapper payload
+Wraps: (2) woo
+Error types: (1) *errbase_test.werrFmt (2) *errbase_test.errNoFmt`, ``,
 		},
 
 		{"fmt-old leaf + nofmt wrap",
@@ -105,30 +191,34 @@ waa:
 			&werrFmto{&errFmto{"woo"}, "waa"},
 			waawoo, `
 woo
--- verbose leaf (fmt):
-woo
--- verbose wrapper (fmt):
-waa`, ``,
+-- this is woo's
+multi-line payload
+-- this is waa's
+multi-line payload (fmt)`, ``,
 		},
 
 		{"fmt-old leaf + fmt-partial wrap",
 			&werrFmtp{&errFmto{"woo"}, "waa"},
 			waawoo, `
-waa:
-  - woo
-    -- verbose leaf (fmt):
-    woo`, ``,
+waa: woo
+(1) waa
+Wraps: (2) woo
+  | -- this is woo's
+  | multi-line payload
+Error types: (1) *errbase_test.werrFmtp (2) *errbase_test.errFmto`, ``,
 		},
 
 		{"fmt-old leaf + fmt wrap",
 			&werrFmt{&errFmto{"woo"}, "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - woo
-    -- verbose leaf (fmt):
-    woo`, ``,
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line wrapper payload
+Wraps: (2) woo
+  | -- this is woo's
+  | multi-line payload
+Error types: (1) *errbase_test.werrFmt (2) *errbase_test.errFmto`, ``,
 		},
 
 		{"fmt-partial leaf + nofmt wrap",
@@ -139,24 +229,34 @@ waa:
 			&werrFmto{&errFmtp{"woo"}, "waa"},
 			waawoo, `
 woo
--- verbose wrapper (fmt):
-waa`, ``,
+(1) woo
+Error types: (1) *errbase_test.errFmtp
+-- this is waa's
+multi-line payload (fmt)`, ``,
 		},
 
 		{"fmt-partial leaf + fmt-partial wrap",
 			&werrFmtp{&errFmtp{"woo"}, "waa"},
 			waawoo, `
-waa:
-  - woo`, ``,
+waa: woo
+(1) waa
+Wraps: (2) woo
+  | (1) woo
+  | Error types: (1) *errbase_test.errFmtp
+Error types: (1) *errbase_test.werrFmtp (2) *errbase_test.errFmtp`, ``,
 		},
 
 		{"fmt-partial leaf + fmt wrap",
 			&werrFmt{&errFmtp{"woo"}, "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - woo`, ``,
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line wrapper payload
+Wraps: (2) woo
+  | (1) woo
+  | Error types: (1) *errbase_test.errFmtp
+Error types: (1) *errbase_test.werrFmt (2) *errbase_test.errFmtp`, ``,
 		},
 
 		{"fmt leaf + nofmt wrap",
@@ -166,31 +266,37 @@ waa:
 		{"fmt leaf + fmt-old wrap",
 			&werrFmto{&errFmt{"woo"}, "waa"},
 			waawoo, `
-woo:
-    -- verbose leaf:
-    woo
--- verbose wrapper (fmt):
-waa`, ``,
+woo
+(1) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.errFmt
+-- this is waa's
+multi-line payload (fmt)`, ``,
 		},
 
 		{"fmt leaf + fmt-partial wrap",
 			&werrFmtp{&errFmt{"woo"}, "waa"},
 			waawoo, `
-waa:
-  - woo:
-    -- verbose leaf:
-    woo`, ``,
+waa: woo
+(1) waa
+Wraps: (2) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrFmtp (2) *errbase_test.errFmt`, ``,
 		},
 
 		{"fmt leaf + fmt wrap",
 			&werrFmt{&errFmt{"woo"}, "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - woo:
-    -- verbose leaf:
-    woo`, ``,
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line wrapper payload
+Wraps: (2) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrFmt (2) *errbase_test.errFmt`, ``,
 		},
 
 		{"nofmt wrap in + nofmt wrap out",
@@ -201,20 +307,22 @@ waa:
 			&werrFmto{&werrNoFmt{&errFmt{"woo"}, "waa"}, "wuu"},
 			wuuwaawoo, `
 waa: woo
--- verbose wrapper (fmt):
-wuu`, ``,
+-- this is wuu's
+multi-line payload (fmt)`, ``,
 		},
 
 		{"nofmt wrap in + fmt wrap out",
 			&werrFmt{&werrNoFmt{&errFmt{"woo"}, "waa"}, "wuu"},
 			wuuwaawoo, `
-wuu:
-    -- verbose wrapper:
-    wuu
-  - waa
-  - woo:
-    -- verbose leaf:
-    woo`, ``,
+wuu: waa: woo
+(1) wuu
+  | -- this is wuu's
+  | multi-line wrapper payload
+Wraps: (2) waa
+Wraps: (3) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrFmt (2) *errbase_test.werrNoFmt (3) *errbase_test.errFmt`, ``,
 		},
 
 		{"fmt-old wrap in + nofmt wrap out",
@@ -224,26 +332,29 @@ wuu:
 		{"fmt-old wrap in + fmd-old wrap out",
 			&werrFmto{&werrFmto{&errFmt{"woo"}, "waa"}, "wuu"},
 			wuuwaawoo, `
-woo:
-    -- verbose leaf:
-    woo
--- verbose wrapper (fmt):
-waa
--- verbose wrapper (fmt):
-wuu`, ``,
+woo
+(1) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.errFmt
+-- this is waa's
+multi-line payload (fmt)
+-- this is wuu's
+multi-line payload (fmt)`, ``,
 		},
 
 		{"fmt-old wrap in + fmt wrap out",
 			&werrFmt{&werrFmto{&errFmt{"woo"}, "waa"}, "wuu"},
 			wuuwaawoo, `
-wuu:
-    -- verbose wrapper:
-    wuu
-  - woo:
-        -- verbose leaf:
-        woo
-    -- verbose wrapper (fmt):
-    waa`, ``,
+wuu: waa: woo
+(1) wuu
+  | -- this is wuu's
+  | multi-line wrapper payload
+Wraps: (2) waa
+Wraps: (3) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrFmt (2) *errbase_test.werrFmto (3) *errbase_test.errFmt`, ``,
 		},
 
 		{"fmt wrap in + nofmt wrap out",
@@ -253,66 +364,82 @@ wuu:
 		{"fmt wrap in + fmd-old wrap out",
 			&werrFmto{&werrFmt{&errFmt{"woo"}, "waa"}, "wuu"},
 			wuuwaawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - woo:
-    -- verbose leaf:
-    woo
--- verbose wrapper (fmt):
-wuu`, ``,
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line wrapper payload
+Wraps: (2) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrFmt (2) *errbase_test.errFmt
+-- this is wuu's
+multi-line payload (fmt)`, ``,
 		},
 
 		{"fmt wrap in + fmt wrap out",
 			&werrFmt{&werrFmt{&errFmt{"woo"}, "waa"}, "wuu"},
 			wuuwaawoo, `
-wuu:
-    -- verbose wrapper:
-    wuu
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo:
-    -- verbose leaf:
-    woo`, ``,
+wuu: waa: woo
+(1) wuu
+  | -- this is wuu's
+  | multi-line wrapper payload
+Wraps: (2) waa
+  | -- this is waa's
+  | multi-line wrapper payload
+Wraps: (3) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrFmt (2) *errbase_test.werrFmt (3) *errbase_test.errFmt`, ``,
 		},
 
 		// Opaque leaf.
 		{"opaque leaf",
 			errbase.DecodeError(ctx, errbase.EncodeError(ctx, &errNoFmt{"woo"})),
 			woo, `
-woo:
-    (opaque error leaf)
-    type name: github.com/cockroachdb/errors/errbase_test/*errbase_test.errNoFmt`, ``},
+woo
+(1) woo
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/errbase_test/*errbase_test.errNoFmt
+Error types: (1) *errbase.opaqueLeaf`, ``},
 
 		// Opaque wrapper.
 		{"opaque wrapper",
 			errbase.DecodeError(ctx, errbase.EncodeError(ctx, &werrNoFmt{goErr.New("woo"), "waa"})),
 			waawoo, `
-waa:
-    (opaque error wrapper)
-    type name: github.com/cockroachdb/errors/errbase_test/*errbase_test.werrNoFmt
-  - woo`, ``},
+waa: woo
+(1) waa
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/errbase_test/*errbase_test.werrNoFmt
+Wraps: (2) woo
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString`, ``},
 
 		{"opaque wrapper+wrapper",
 			errbase.DecodeError(ctx, errbase.EncodeError(ctx, &werrNoFmt{&werrNoFmt{goErr.New("woo"), "waa"}, "wuu"})),
 			wuuwaawoo, `
-wuu:
-    (opaque error wrapper)
-    type name: github.com/cockroachdb/errors/errbase_test/*errbase_test.werrNoFmt
-  - waa:
-    (opaque error wrapper)
-    type name: github.com/cockroachdb/errors/errbase_test/*errbase_test.werrNoFmt
-  - woo`, ``},
+wuu: waa: woo
+(1) wuu
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/errbase_test/*errbase_test.werrNoFmt
+Wraps: (2) waa
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/errbase_test/*errbase_test.werrNoFmt
+Wraps: (3) woo
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errors.errorString`, ``},
 
 		// Compatibility with github.com/pkg/errors.
 
 		{"pkg msg + fmt leaf",
 			pkgErr.WithMessage(&errFmt{"woo"}, "waa"),
 			waawoo, `
-woo:
-    -- verbose leaf:
-    woo
+woo
+(1) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.errFmt
 waa`,
 			// The implementation of (*pkgErr.withMessage).Format() is wrong for %q. Oh well...
 			`waa: woo`,
@@ -321,13 +448,15 @@ waa`,
 		{"fmt wrap + pkg msg + fmt leaf",
 			&werrFmt{pkgErr.WithMessage(&errFmt{"woo"}, "waa"), "wuu"},
 			wuuwaawoo, `
-wuu:
-    -- verbose wrapper:
-    wuu
-  - woo:
-        -- verbose leaf:
-        woo
-    waa`, ``,
+wuu: waa: woo
+(1) wuu
+  | -- this is wuu's
+  | multi-line wrapper payload
+Wraps: (2) waa
+Wraps: (3) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrFmt (2) *errors.withMessage (3) *errbase_test.errFmt`, ``,
 		},
 
 		{"fmt wrap + pkg msg1 + pkg.msg2 + fmt leaf",
@@ -338,31 +467,36 @@ wuu:
 					"waa1"),
 				"wuu"},
 			`wuu: waa1: waa2: woo`, `
-wuu:
-    -- verbose wrapper:
-    wuu
-  - woo:
-        -- verbose leaf:
-        woo
-    waa2
-    waa1`, ``,
+wuu: waa1: waa2: woo
+(1) wuu
+  | -- this is wuu's
+  | multi-line wrapper payload
+Wraps: (2) waa1
+Wraps: (3) waa2
+Wraps: (4) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrFmt (2) *errors.withMessage (3) *errors.withMessage (4) *errbase_test.errFmt`, ``,
 		},
 
 		{"fmt wrap + pkg stack + fmt leaf",
 			&werrFmt{pkgErr.WithStack(&errFmt{"woo"}), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - woo:
-        -- verbose leaf:
-        woo
-    github.com/cockroachdb/errors/errbase_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>`, ``,
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line wrapper payload
+Wraps: (2)
+  | github.com/cockroachdb/errors/errbase_test.TestFormat
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrFmt (2) *errors.withStack (3) *errbase_test.errFmt`, ``,
 		},
 	}
 
@@ -371,26 +505,31 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := test.expFmtQuote
 			if ref == "" {
 				ref = fmt.Sprintf("%q", test.expFmtSimple)
 			}
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
-			spv := fmt.Sprintf("%+v", err)
-			spv = fileref.ReplaceAllString(spv, "<path>")
-			spv = strings.ReplaceAll(spv, "\t", "<tab>")
-			tt.CheckEqual(spv, refV)
+			spv := fmtClean(err)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
+}
+
+func fmtClean(x interface{}) string {
+	spv := fmt.Sprintf("%+v", x)
+	spv = fileref.ReplaceAllString(spv, "<path>:<lineno>")
+	spv = strings.ReplaceAll(spv, "\t", "<tab>")
+	return spv
 }
 
 var fileref = regexp.MustCompile(`([a-zA-Z0-9\._/@-]*\.(?:go|s):\d+)`)
@@ -422,7 +561,7 @@ func (e *errFmto) Format(s fmt.State, verb rune) {
 	case 'v':
 		if s.Flag('+') {
 			fmt.Fprint(s, e.msg)
-			fmt.Fprintf(s, "\n-- verbose leaf (fmt):\n%s", e.msg)
+			fmt.Fprintf(s, "\n-- this is %s's\nmulti-line payload", e.msg)
 			return
 		}
 		fallthrough
@@ -444,7 +583,7 @@ func (e *werrFmto) Format(s fmt.State, verb rune) {
 	case 'v':
 		if s.Flag('+') {
 			fmt.Fprintf(s, "%+v", e.cause)
-			fmt.Fprintf(s, "\n-- verbose wrapper (fmt):\n%s", e.msg)
+			fmt.Fprintf(s, "\n-- this is %s's\nmulti-line payload (fmt)", e.msg)
 			return
 		}
 		fallthrough
@@ -482,7 +621,7 @@ func (e *errFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb
 func (e *errFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose leaf:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line leaf payload", e.msg)
 	}
 	return nil
 }
@@ -499,7 +638,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line wrapper payload", e.msg)
 	}
 	return e.cause
 }

--- a/errutil/fmt_wrap_test.go
+++ b/errutil/fmt_wrap_test.go
@@ -47,53 +47,42 @@ func TestErrorWrap(t *testing.T) {
 			errutil.Wrap(fmt.Errorf("hello: %w", baseErr), "woo"),
 			`woo: hello: world`,
 			// However, ours do.
-			`error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - woo:
-  - hello
-  - error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - world`},
+			`woo: hello: world
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestErrorWrap
+  | <tab><path>
+  | [...repeated from below...]
+Wraps: (2) woo
+Wraps: (3) hello
+Wraps: (4) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestErrorWrap
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (5) world
+Error types: (1) *withstack.withStack (2) *errutil.withMessage (3) *fmt.wrapError (4) *withstack.withStack (5) *errors.errorString`},
 
 		{"new wrap err",
 			errutil.Newf("hello: %w", baseErr),
 			`hello: world`,
-			`error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - error with embedded safe details: hello: %w
-    -- arg 1: <*errors.errorString>
-    wrapper: <*withstack.withStack>
-    (more details:)
-    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - hello
-  - error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestErrorWrap
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - world`},
+			`hello: world
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestErrorWrap
+  | <tab><path>
+  | [...repeated from below...]
+Wraps: (2) 2 safe details enclosed
+Wraps: (3) hello
+Wraps: (4) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestErrorWrap
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (5) world
+Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *fmt.wrapError (4) *withstack.withStack (5) *errors.errorString`},
 	}
 
 	for _, test := range testCases {
@@ -101,21 +90,21 @@ func TestErrorWrap(t *testing.T) {
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
 			spv = fileref.ReplaceAllString(spv, "<path>")
 			spv = strings.ReplaceAll(spv, "\t", "<tab>")
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }

--- a/errutil/message_test.go
+++ b/errutil/message_test.go
@@ -41,178 +41,206 @@ func TestFormat(t *testing.T) {
 					goErr.New("woo"), "waa"),
 				"wuu"},
 			`wuu: waa: woo`, `
-wuu:
-    -- verbose wrapper:
-    wuu
-  - waa:
-  - woo`,
+wuu: waa: woo
+(1) wuu
+  | -- this is wuu's
+  | multi-line payload
+Wraps: (2) waa
+Wraps: (3) woo
+Error types: (1) *errutil_test.werrFmt (2) *errutil.withMessage (3) *errors.errorString`,
 		},
 
 		{"newf",
 			errutil.Newf("waa: %s", "hello"),
 			`waa: hello`, `
-error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - error with embedded safe details: waa: %s
-    -- arg 1: <string>
-  - waa: hello`,
+waa: hello
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (2) 2 safe details enclosed
+Wraps: (3) waa: hello
+Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errors.errorString`,
 		},
 
 		{"newf-empty",
 			errutil.Newf(emptyString),
 			``, `
-error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - `,
+
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (2)
+Error types: (1) *withstack.withStack (2) *errors.errorString`,
 		},
 
 		{"newf-empty-arg",
 			errutil.Newf(emptyString, 123),
 			`%!(EXTRA int=123)`, `
-error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - error with embedded safe details:
-    -- arg 1: <int>
-  - %!(EXTRA int=123)`,
+%!(EXTRA int=123)
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (2) 2 safe details enclosed
+Wraps: (3) %!(EXTRA int=123)
+Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errors.errorString`,
 		},
 
 		{"wrapf",
 			errutil.Wrapf(goErr.New("woo"), "waa: %s", "hello"),
 			`waa: hello: woo`, `
-error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - error with embedded safe details: waa: %s
-    -- arg 1: <string>
-  - waa: hello:
-  - woo`,
+waa: hello: woo
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (2) 2 safe details enclosed
+Wraps: (3) waa: hello
+Wraps: (4) woo
+Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errutil.withMessage (4) *errors.errorString`,
 		},
 
 		{"wrapf-empty",
 			errutil.Wrapf(goErr.New("woo"), emptyString),
 			`woo`, `
-error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - woo`,
+woo
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (2) woo
+Error types: (1) *withstack.withStack (2) *errors.errorString`,
 		},
 
 		{"wrapf-empty-arg",
 			errutil.Wrapf(goErr.New("woo"), emptyString, 123),
 			`%!(EXTRA int=123): woo`, `
-error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - error with embedded safe details:
-    -- arg 1: <int>
-  - %!(EXTRA int=123):
-  - woo`,
+%!(EXTRA int=123): woo
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (2) 2 safe details enclosed
+Wraps: (3) %!(EXTRA int=123)
+Wraps: (4) woo
+Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errutil.withMessage (4) *errors.errorString`,
 		},
 
 		{"handled assert",
 			errutil.HandleAsAssertionFailure(&werrFmt{goErr.New("woo"), "wuu"}),
 			`wuu: woo`,
 			`
-assertion failure
-  - error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - wuu: woo:
-    original cause behind barrier: wuu:
-        -- verbose wrapper:
-        wuu
-      - woo`,
+wuu: woo
+(1) assertion failure
+Wraps: (2) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (3) wuu: woo
+  | -- cause hidden behind barrier
+  | wuu: woo
+  | (1) wuu
+  |   | -- this is wuu's
+  |   | multi-line payload
+  | Wraps: (2) woo
+  | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError`,
 		},
 
 		{"assert + wrap",
 			errutil.NewAssertionErrorWithWrappedErrf(&werrFmt{goErr.New("woo"), "wuu"}, "waa: %s", "hello"),
 			`waa: hello: wuu: woo`, `
-assertion failure
-  - error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - error with embedded safe details: waa: %s
-    -- arg 1: <string>
-  - waa: hello:
-  - wuu: woo:
-    original cause behind barrier: wuu:
-        -- verbose wrapper:
-        wuu
-      - woo`,
+waa: hello: wuu: woo
+(1) assertion failure
+Wraps: (2) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (3) 2 safe details enclosed
+Wraps: (4) waa: hello
+Wraps: (5) wuu: woo
+  | -- cause hidden behind barrier
+  | wuu: woo
+  | (1) wuu
+  |   | -- this is wuu's
+  |   | multi-line payload
+  | Wraps: (2) woo
+  | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *safedetails.withSafeDetails (4) *errutil.withMessage (5) *barriers.barrierError`,
 		},
 
 		{"assert + wrap empty",
 			errutil.NewAssertionErrorWithWrappedErrf(&werrFmt{goErr.New("woo"), "wuu"}, emptyString),
 			`wuu: woo`, `
-assertion failure
-  - error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - wuu: woo:
-    original cause behind barrier: wuu:
-        -- verbose wrapper:
-        wuu
-      - woo`,
+wuu: woo
+(1) assertion failure
+Wraps: (2) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (3) wuu: woo
+  | -- cause hidden behind barrier
+  | wuu: woo
+  | (1) wuu
+  |   | -- this is wuu's
+  |   | multi-line payload
+  | Wraps: (2) woo
+  | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError`,
 		},
 
 		{"assert + wrap empty+arg",
 			errutil.NewAssertionErrorWithWrappedErrf(&werrFmt{goErr.New("woo"), "wuu"}, emptyString, 123),
 			`%!(EXTRA int=123): wuu: woo`, `
-assertion failure
-  - error with attached stack trace:
-    github.com/cockroachdb/errors/errutil_test.TestFormat
-    <tab><path>
-    testing.tRunner
-    <tab><path>
-    runtime.goexit
-    <tab><path>
-  - error with embedded safe details:
-    -- arg 1: <int>
-  - %!(EXTRA int=123):
-  - wuu: woo:
-    original cause behind barrier: wuu:
-        -- verbose wrapper:
-        wuu
-      - woo`,
+%!(EXTRA int=123): wuu: woo
+(1) assertion failure
+Wraps: (2) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (3) 2 safe details enclosed
+Wraps: (4) %!(EXTRA int=123)
+Wraps: (5) wuu: woo
+  | -- cause hidden behind barrier
+  | wuu: woo
+  | (1) wuu
+  |   | -- this is wuu's
+  |   | multi-line payload
+  | Wraps: (2) woo
+  | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *safedetails.withSafeDetails (4) *errutil.withMessage (5) *barriers.barrierError`,
 		},
 	}
 
@@ -221,21 +249,21 @@ assertion failure
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
 			spv = fileref.ReplaceAllString(spv, "<path>")
 			spv = strings.ReplaceAll(spv, "\t", "<tab>")
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -255,7 +283,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/extgrpc/ext_grpc_test.go
+++ b/extgrpc/ext_grpc_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/extgrpc"
 	"github.com/cockroachdb/errors/testutils"
-
 	"google.golang.org/grpc/codes"
 )
 
@@ -47,10 +46,13 @@ func TestGrpc(t *testing.T) {
 	tt.CheckEqual(extgrpc.GetGrpcCode(otherErr), codes.NotFound)
 
 	// The code is hidden when the error is printed with %v.
-	tt.CheckEqual(fmt.Sprintf("%v", err), `hello`)
+	tt.CheckStringEqual(fmt.Sprintf("%v", err), `hello`)
 	// The code appears when the error is printed verbosely.
-	tt.CheckEqual(fmt.Sprintf("%+v", err), `gRPC code: Unavailable
-  - hello`)
+	tt.CheckStringEqual(fmt.Sprintf("%+v", err), `hello
+(1)
+  | gRPC code: Unavailable
+Wraps: (2) hello
+Error types: (1) *extgrpc.withGrpcCode (2) *errors.errorString`)
 
 	// Checking the code of a nil error should be codes.OK
 	var noErr error

--- a/exthttp/ext_http_test.go
+++ b/exthttp/ext_http_test.go
@@ -45,8 +45,11 @@ func TestHTTP(t *testing.T) {
 	tt.CheckEqual(exthttp.GetHTTPCode(otherErr, 100), 404)
 
 	// The code is hidden when the error is printed with %v.
-	tt.CheckEqual(fmt.Sprintf("%v", err), `hello`)
+	tt.CheckStringEqual(fmt.Sprintf("%v", err), `hello`)
 	// The code appears when the error is printed verbosely.
-	tt.CheckEqual(fmt.Sprintf("%+v", err), `http code: 302
-  - hello`)
+	tt.CheckStringEqual(fmt.Sprintf("%+v", err), `hello
+(1)
+  | http code: 302
+Wraps: (2) hello
+Error types: (1) *exthttp.withHTTPCode (2) *errors.errorString`)
 }

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/grpc/status"
 	"github.com/cockroachdb/errors/testutils"
-
 	"google.golang.org/grpc/codes"
 )
 
@@ -50,5 +49,7 @@ func TestGrpc(t *testing.T) {
 	tt.Assert(err.Error() == "there was a problem: internal error!")
 	tt.Assert(status.Code(err) == codes.Internal)
 	tt.Assert(errors.Is(err, ErrInternal))
-	tt.Assert(strings.HasPrefix(fmt.Sprintf("%+v", err), "gRPC code: Internal"))
+	spv := fmt.Sprintf("%+v", err)
+	t.Logf("spv:\n%s", spv)
+	tt.Assert(strings.Contains(spv, "gRPC code: Internal"))
 }

--- a/hintdetail/with_detail.go
+++ b/hintdetail/with_detail.go
@@ -41,9 +41,7 @@ func (w *withDetail) Unwrap() error       { return w.cause }
 func (w *withDetail) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withDetail) FormatError(p errbase.Printer) error {
-	if p.Detail() {
-		p.Printf("error with user detail: %s", w.detail)
-	}
+	p.Print(w.detail)
 	return w.cause
 }
 

--- a/hintdetail/with_hint.go
+++ b/hintdetail/with_hint.go
@@ -41,9 +41,7 @@ func (w *withHint) Unwrap() error     { return w.cause }
 func (w *withHint) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withHint) FormatError(p errbase.Printer) error {
-	if p.Detail() {
-		p.Printf("error with user hint: %s", w.hint)
-	}
+	p.Print(w.hint)
 	return w.cause
 }
 

--- a/issuelink/issuelink_test.go
+++ b/issuelink/issuelink_test.go
@@ -44,7 +44,7 @@ func TestIssueLink(t *testing.T) {
 
 	theTest := func(tt testutils.T, err error) {
 		tt.Check(markers.Is(err, origErr))
-		tt.CheckEqual(err.Error(), "hello: world")
+		tt.CheckStringEqual(err.Error(), "hello: world")
 
 		tt.Check(issuelink.HasIssueLink(err))
 		if _, ok := markers.If(err, func(err error) (interface{}, bool) { return nil, issuelink.IsIssueLink(err) }); !ok {
@@ -89,36 +89,40 @@ func TestFormat(t *testing.T) {
 		{"link",
 			issuelink.WithIssueLink(baseErr, link),
 			woo, `
-error with linked issue
-    issue: http://mysite
-  - woo`},
+woo
+(1) issue: http://mysite
+Wraps: (2) woo
+Error types: (1) *issuelink.withIssueLink (2) *errors.errorString`},
 		{"link-details",
 			issuelink.WithIssueLink(baseErr, issuelink.IssueLink{IssueURL: "http://mysite", Detail: "see more"}),
 			woo, `
-error with linked issue
-    issue: http://mysite
-    detail: see more
-  - woo`},
+woo
+(1) issue: http://mysite
+  | detail: see more
+Wraps: (2) woo
+Error types: (1) *issuelink.withIssueLink (2) *errors.errorString`},
 
 		{"link + wrapper",
 			issuelink.WithIssueLink(&werrFmt{baseErr, "waa"}, link),
 			waawoo, `
-error with linked issue
-    issue: http://mysite
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+waa: woo
+(1) issue: http://mysite
+Wraps: (2) waa
+  | -- this is waa's
+  | multi-line payload
+Wraps: (3) woo
+Error types: (1) *issuelink.withIssueLink (2) *issuelink_test.werrFmt (3) *errors.errorString`},
 
 		{"wrapper + link",
 			&werrFmt{issuelink.WithIssueLink(baseErr, link), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - error with linked issue
-    issue: http://mysite
-  - woo`},
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line payload
+Wraps: (2) issue: http://mysite
+Wraps: (3) woo
+Error types: (1) *issuelink_test.werrFmt (2) *issuelink.withIssueLink (3) *errors.errorString`},
 	}
 
 	for _, test := range testCases {
@@ -126,19 +130,19 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }
@@ -156,7 +160,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/issuelink/unimplemented_error.go
+++ b/issuelink/unimplemented_error.go
@@ -52,15 +52,12 @@ const UnimplementedErrorHint = `You have attempted to use a feature that is not 
 func (w *unimplementedError) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *unimplementedError) FormatError(p errbase.Printer) error {
-	p.Print(w.msg)
-	if p.Detail() {
-		p.Print("\n(unimplemented error)")
-		if w.IssueURL != "" {
-			p.Printf("\nissue: %s", w.IssueURL)
-		}
-		if w.Detail != "" {
-			p.Printf("\ndetail: %s", w.Detail)
-		}
+	p.Printf("unimplemented: %s", w.msg)
+	if w.IssueURL != "" {
+		p.Printf("\nissue: %s", w.IssueURL)
+	}
+	if w.Detail != "" {
+		p.Printf("\ndetail: %s", w.Detail)
 	}
 	return nil
 }

--- a/issuelink/unimplemented_test.go
+++ b/issuelink/unimplemented_test.go
@@ -75,26 +75,29 @@ func TestFormatUnimp(t *testing.T) {
 		{"unimp",
 			issuelink.UnimplementedError(link, "woo"),
 			woo, `
-woo:
-    (unimplemented error)
-    issue: http://mysite`},
+woo
+(1) unimplemented: woo
+  | issue: http://mysite
+Error types: (1) *issuelink.unimplementedError`},
 		{"unimp-details",
 			issuelink.UnimplementedError(issuelink.IssueLink{IssueURL: "http://mysite", Detail: "see more"}, "woo"),
 			woo, `
-woo:
-    (unimplemented error)
-    issue: http://mysite
-    detail: see more`},
+woo
+(1) unimplemented: woo
+  | issue: http://mysite
+  | detail: see more
+Error types: (1) *issuelink.unimplementedError`},
 
 		{"wrapper + unimp",
 			&werrFmt{issuelink.UnimplementedError(link, "woo"), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - woo:
-    (unimplemented error)
-    issue: http://mysite`},
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line payload
+Wraps: (2) unimplemented: woo
+  | issue: http://mysite
+Error types: (1) *issuelink_test.werrFmt (2) *issuelink.unimplementedError`},
 	}
 
 	for _, test := range testCases {
@@ -102,19 +105,19 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
 		})
 	}
 }

--- a/issuelink/with_issuelink.go
+++ b/issuelink/with_issuelink.go
@@ -65,14 +65,13 @@ func maybeAppendReferral(buf *bytes.Buffer, link IssueLink) {
 func (w *withIssueLink) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withIssueLink) FormatError(p errbase.Printer) error {
-	if p.Detail() {
-		p.Print("error with linked issue")
-		if w.IssueURL != "" {
-			p.Printf("\nissue: %s", w.IssueURL)
-		}
-		if w.Detail != "" {
-			p.Printf("\ndetail: %s", w.Detail)
-		}
+	sep := ""
+	if w.IssueURL != "" {
+		p.Printf("issue: %s", w.IssueURL)
+		sep = "\n"
+	}
+	if w.Detail != "" {
+		p.Printf("%sdetail: %s", sep, w.Detail)
 	}
 	return w.cause
 }

--- a/markers/markers.go
+++ b/markers/markers.go
@@ -202,8 +202,9 @@ func (m *withMark) Unwrap() error { return m.cause }
 func (m *withMark) Format(s fmt.State, verb rune) { errbase.FormatError(m, s, verb) }
 
 func (m *withMark) FormatError(p errbase.Printer) error {
+	p.Print("forced error mark")
 	if p.Detail() {
-		p.Printf("error with mark override:\n%q\n%s::%s",
+		p.Printf("%q\n%s::%s",
 			m.mark.msg,
 			m.mark.types[0].FamilyName,
 			m.mark.types[0].Extension,

--- a/safedetails/safedetails_test.go
+++ b/safedetails/safedetails_test.go
@@ -42,17 +42,16 @@ func TestDetailCapture(t *testing.T) {
 		tt.Check(markers.Is(err, origErr))
 
 		// The message is unchanged by the wrapper.
-		tt.CheckEqual(err.Error(), "hello world")
+		tt.CheckStringEqual(err.Error(), "hello world")
 
-		// The unsafe string is hidden.
+		// The detail strings are hidden.
 		errV := fmt.Sprintf("%+v", err)
 		tt.Check(!strings.Contains(errV, "and universe"))
+		tt.Check(!strings.Contains(errV, "planet"))
+		tt.Check(!strings.Contains(errV, "bye %s %s"))
 
-		// The safe string is preserved.
-		tt.Check(strings.Contains(errV, "planet"))
-
-		// The format string is preserved.
-		tt.Check(strings.Contains(errV, "bye %s %s"))
+		// The fact there are details is preserved.
+		tt.Check(strings.Contains(errV, "3 safe details enclosed"))
 	}
 
 	// Check the error properties locally.
@@ -80,25 +79,49 @@ func TestFormat(t *testing.T) {
 		err           error
 		expFmtSimple  string
 		expFmtVerbose string
+		details       string
 	}{
 		{"safe onearg",
 			safedetails.WithSafeDetails(baseErr, "a"),
 			woo, `
-error with embedded safe details: a
-  - woo`},
+woo
+(1) 1 safe detail enclosed
+Wraps: (2) woo
+Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
+			// Payload
+			`payload 0
+(0) a
+payload 1
+(empty)
+`},
 
 		{"safe empty",
 			safedetails.WithSafeDetails(baseErr, ""),
 			woo, `
-safe detail wrapper with no details
-  - woo`},
+woo
+(1) 1 safe detail enclosed
+Wraps: (2) woo
+Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
+			// Payload
+			`payload 0
+(empty)
+payload 1
+(empty)
+`},
 
 		{"safe nofmt+onearg",
 			safedetails.WithSafeDetails(baseErr, "", 123),
 			woo, `
-error with embedded safe details:
-    -- arg 1: <int>
-  - woo`},
+woo
+(1) 2 safe details enclosed
+Wraps: (2) woo
+Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
+			// Payload
+			`payload 0
+(1) -- arg 1: <int>
+payload 1
+(empty)
+`},
 
 		{"safe err",
 			safedetails.WithSafeDetails(baseErr, "a %v",
@@ -108,62 +131,138 @@ error with embedded safe details:
 					Err:  os.ErrNotExist,
 				}),
 			woo, `
-error with embedded safe details: a %v
-    -- arg 1: *errors.errorString: file does not exist
-    wrapper: *os.PathError: open
-  - woo`},
+woo
+(1) 2 safe details enclosed
+Wraps: (2) woo
+Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
+			// Payload
+			`payload 0
+(0) a %v
+(1) -- arg 1: *errors.errorString: file does not exist
+wrapper: *os.PathError: open
+payload 1
+(empty)
+`},
 
 		{"safe",
 			safedetails.WithSafeDetails(baseErr, "a %s %s", "b", safedetails.Safe("c")),
 			woo, `
-error with embedded safe details: a %s %s
-    -- arg 1: <string>
-    -- arg 2: c
-  - woo`},
+woo
+(1) 3 safe details enclosed
+Wraps: (2) woo
+Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
+			// Payload
+			`payload 0
+(0) a %s %s
+(1) -- arg 1: <string>
+(2) -- arg 2: c
+payload 1
+(empty)
+`},
 
 		{"safe + wrapper",
 			safedetails.WithSafeDetails(&werrFmt{baseErr, "waa"}, "a %s %s", "b", safedetails.Safe("c")),
 			waawoo, `
-error with embedded safe details: a %s %s
-    -- arg 1: <string>
-    -- arg 2: c
-  - waa:
-    -- verbose wrapper:
-    waa
-  - woo`},
+waa: woo
+(1) 3 safe details enclosed
+Wraps: (2) waa
+  | -- this is waa's
+  | multi-line payload
+Wraps: (3) woo
+Error types: (1) *safedetails.withSafeDetails (2) *safedetails_test.werrFmt (3) *errors.errorString`,
+			// Payload
+			`payload 0
+(0) a %s %s
+(1) -- arg 1: <string>
+(2) -- arg 2: c
+payload 1
+(empty)
+payload 2
+(empty)
+`},
 
 		{"wrapper + safe",
 			&werrFmt{safedetails.WithSafeDetails(baseErr, "a %s %s", "b", safedetails.Safe("c")), "waa"},
 			waawoo, `
-waa:
-    -- verbose wrapper:
-    waa
-  - error with embedded safe details: a %s %s
-    -- arg 1: <string>
-    -- arg 2: c
-  - woo`},
+waa: woo
+(1) waa
+  | -- this is waa's
+  | multi-line payload
+Wraps: (2) 3 safe details enclosed
+Wraps: (3) woo
+Error types: (1) *safedetails_test.werrFmt (2) *safedetails.withSafeDetails (3) *errors.errorString`,
+			// Payload
+			`payload 0
+(empty)
+payload 1
+(0) a %s %s
+(1) -- arg 1: <string>
+(2) -- arg 2: c
+payload 2
+(empty)
+`},
 
 		{"safe with wrapped error",
 			safedetails.WithSafeDetails(baseErr, "a %v",
 				&werrFmt{errors.New("wuu"), "waa"}),
 			woo,
-			`error with embedded safe details: a %v
-    -- arg 1: <*errors.errorString>
-    wrapper: <*safedetails_test.werrFmt>
-  - woo`},
+			`
+woo
+(1) 2 safe details enclosed
+Wraps: (2) woo
+Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
+			// Payload
+			`payload 0
+(0) a %v
+(1) -- arg 1: <*errors.errorString>
+wrapper: <*safedetails_test.werrFmt>
+payload 1
+(empty)
+`},
 
-		{"safe in safe",
+		{"safe + safe, stacked",
+			safedetails.WithSafeDetails(
+				safedetails.WithSafeDetails(baseErr, "hello %s", safedetails.Safe("world")),
+				"delicious %s", safedetails.Safe("coffee")),
+			woo,
+			`
+woo
+(1) 2 safe details enclosed
+Wraps: (2) 2 safe details enclosed
+Wraps: (3) woo
+Error types: (1) *safedetails.withSafeDetails (2) *safedetails.withSafeDetails (3) *errors.errorString`,
+			// Payload
+			`payload 0
+(0) delicious %s
+(1) -- arg 1: coffee
+payload 1
+(0) hello %s
+(1) -- arg 1: world
+payload 2
+(empty)
+`},
+
+		{"safe as arg to safe",
 			safedetails.WithSafeDetails(baseErr, "a %v",
 				safedetails.WithSafeDetails(errors.New("wuu"),
 					"b %v", safedetails.Safe("waa"))),
 			woo,
-			`error with embedded safe details: a %v
-    -- arg 1: <*errors.errorString>
-    wrapper: <*safedetails.withSafeDetails>
-    (more details:)
-    b %v
-    -- arg 1: waa
-  - woo`},
+			`
+woo
+(1) 2 safe details enclosed
+Wraps: (2) woo
+Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
+			// Payload
+			`payload 0
+(0) a %v
+(1) -- arg 1: <*errors.errorString>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+b %v
+-- arg 1: waa
+payload 1
+(empty)
+`},
 	}
 
 	for _, test := range testCases {
@@ -171,19 +270,37 @@ waa:
 			err := test.err
 
 			// %s is simple formatting
-			tt.CheckEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%s", err), test.expFmtSimple)
 
 			// %v is simple formatting too, for compatibility with the past.
-			tt.CheckEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
+			tt.CheckStringEqual(fmt.Sprintf("%v", err), test.expFmtSimple)
 
 			// %q is always like %s but quotes the result.
 			ref := fmt.Sprintf("%q", test.expFmtSimple)
-			tt.CheckEqual(fmt.Sprintf("%q", err), ref)
+			tt.CheckStringEqual(fmt.Sprintf("%q", err), ref)
 
 			// %+v is the verbose mode.
 			refV := strings.TrimPrefix(test.expFmtVerbose, "\n")
 			spv := fmt.Sprintf("%+v", err)
-			tt.CheckEqual(spv, refV)
+			tt.CheckStringEqual(spv, refV)
+
+			// Check the actual details produced.
+			details := errbase.GetAllSafeDetails(err)
+			var buf strings.Builder
+			for i, d := range details {
+				fmt.Fprintf(&buf, "payload %d\n", i)
+				if len(d.SafeDetails) == 0 || (len(d.SafeDetails) == 1 && d.SafeDetails[0] == "") {
+					fmt.Fprintf(&buf, "(empty)\n")
+					continue
+				}
+				for j, sd := range d.SafeDetails {
+					if len(sd) == 0 {
+						continue
+					}
+					fmt.Fprintf(&buf, "(%d) %s\n", j, sd)
+				}
+			}
+			tt.CheckStringEqual(buf.String(), test.details)
 		})
 	}
 }
@@ -201,7 +318,7 @@ func (e *werrFmt) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, ver
 func (e *werrFmt) FormatError(p errbase.Printer) error {
 	p.Print(e.msg)
 	if p.Detail() {
-		p.Printf("-- verbose wrapper:\n%s", e.msg)
+		p.Printf("-- this is %s's\nmulti-line payload", e.msg)
 	}
 	return e.cause
 }

--- a/safedetails/with_safedetails.go
+++ b/safedetails/with_safedetails.go
@@ -33,25 +33,16 @@ func (e *withSafeDetails) SafeDetails() []string {
 }
 
 var _ fmt.Formatter = (*withSafeDetails)(nil)
-var _ errbase.Formatter = (*withSafeDetails)(nil)
 
 // Printing a withSecondary reveals the details.
 func (e *withSafeDetails) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
 
 func (e *withSafeDetails) FormatError(p errbase.Printer) error {
-	if p.Detail() {
-		if len(e.safeDetails) == 0 || (len(e.safeDetails) == 1 && e.safeDetails[0] == "") {
-			p.Print("safe detail wrapper with no details")
-		} else {
-			p.Print("error with embedded safe details:")
-			if e.safeDetails[0] != "" {
-				p.Printf(" %s", e.safeDetails[0])
-			}
-			for _, d := range e.safeDetails[1:] {
-				p.Printf("\n%s", d)
-			}
-		}
+	plural := "s"
+	if len(e.safeDetails) == 1 {
+		plural = ""
 	}
+	p.Printf("%d safe detail%s enclosed", len(e.safeDetails), plural)
 	return e.cause
 }
 

--- a/secondary/with_secondary.go
+++ b/secondary/with_secondary.go
@@ -49,9 +49,9 @@ func (e *withSecondaryError) SafeDetails() []string {
 func (e *withSecondaryError) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
 
 func (e *withSecondaryError) FormatError(p errbase.Printer) (next error) {
+	p.Print("secondary error attachment")
 	if p.Detail() {
-		p.Printf("combined error\nancillary error: %+v", e.secondaryError)
-		p.Print("\n(main error follows)")
+		p.Printf("%+v", e.secondaryError)
 	}
 	return e.cause
 }

--- a/telemetrykeys/with_telemetry.go
+++ b/telemetrykeys/with_telemetry.go
@@ -41,9 +41,7 @@ func (w *withTelemetry) SafeDetails() []string { return w.keys }
 func (w *withTelemetry) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withTelemetry) FormatError(p errbase.Printer) (next error) {
-	if p.Detail() {
-		p.Printf("error with telemetry keys: %+v", w.keys)
-	}
+	p.Printf("keys: %+v", w.keys)
 	return w.cause
 }
 

--- a/testutils/simplecheck.go
+++ b/testutils/simplecheck.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 
@@ -123,6 +124,27 @@ func (t *T) CheckEqual(val, ref interface{}) {
 	if val != ref {
 		t.failWithf(false, "values not equal\n     got: %# v\nexpected: %# v",
 			pretty.Formatter(val), pretty.Formatter(ref))
+	}
+}
+
+// CheckEqual checks that the string value is equal to some reference.
+func (t *T) CheckStringEqual(val, ref string) {
+	t.Helper()
+	if val != ref {
+		pat := regexp.QuoteMeta(ref)
+		pat = strings.ReplaceAll(pat, "\n", `\n`)
+		pat = strings.ReplaceAll(pat, "'", `'"'"'`)
+		pat = strings.ReplaceAll(pat, "\t", `\t`)
+		repl := strings.ReplaceAll(val, "\n", `\n`)
+		repl = strings.ReplaceAll(repl, "'", `'"'"'`)
+		repl = strings.ReplaceAll(repl, "\t", `\t`)
+		_, file, _, _ := runtime.Caller(1)
+		t.failWithf(false, "values not equal; got:\n  %s\nexpected:\n  %s\nTo update expected, run:\n  perl -0777 -pi -ne 's@%s@%s@ms' %s",
+			strings.ReplaceAll(val, "\n", "\n  "),
+			strings.ReplaceAll(ref, "\n", "\n  "),
+			pat, repl, file,
+		)
+
 	}
 }
 

--- a/withstack/one_line_source.go
+++ b/withstack/one_line_source.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors/errbase"
-	pkgErr "github.com/pkg/errors"
 )
 
 // GetOneLineSource extracts the file/line/function information
@@ -40,7 +39,7 @@ func GetOneLineSource(err error) (file string, line int, fn string, ok bool) {
 
 	// If we have a stack trace in the style of github.com/pkg/errors
 	// (either from there or our own withStack), use it.
-	if st, ok := err.(interface{ StackTrace() pkgErr.StackTrace }); ok {
+	if st, ok := err.(errbase.StackTraceProvider); ok {
 		return getOneLineSourceFromPkgStack(st.StackTrace())
 	}
 
@@ -62,7 +61,7 @@ func GetOneLineSource(err error) (file string, line int, fn string, ok bool) {
 }
 
 func getOneLineSourceFromPkgStack(
-	st pkgErr.StackTrace,
+	st errbase.StackTrace,
 ) (file string, line int, fn string, ok bool) {
 	if len(st) > 0 {
 		st = st[:1]

--- a/withstack/reportable.go
+++ b/withstack/reportable.go
@@ -46,7 +46,7 @@ type ReportableStackTrace = sentry.Stacktrace
 func GetReportableStackTrace(err error) *ReportableStackTrace {
 	// If we have a stack trace in the style of github.com/pkg/errors
 	// (either from there or our own withStack), use it.
-	if st, ok := err.(interface{ StackTrace() pkgErr.StackTrace }); ok {
+	if st, ok := err.(errbase.StackTraceProvider); ok {
 		return convertPkgStack(st.StackTrace())
 	}
 
@@ -71,7 +71,7 @@ type frame = sentry.Frame
 
 // convertPkgStack converts a StackTrace from github.com/pkg/errors
 // to a Stacktrace in github.com/getsentry/sentry-go.
-func convertPkgStack(st pkgErr.StackTrace) *ReportableStackTrace {
+func convertPkgStack(st errbase.StackTrace) *ReportableStackTrace {
 	// If there are no frames, the entire stacktrace is nil.
 	if len(st) == 0 {
 		return nil

--- a/withstack/stack.go
+++ b/withstack/stack.go
@@ -18,16 +18,8 @@ import (
 	"fmt"
 	"runtime"
 
-	pkgErr "github.com/pkg/errors"
+	"github.com/cockroachdb/errors/errbase"
 )
-
-// StackTrace is the type of the data for a call stack.
-// This mirrors the type of the same name in github.com/pkg/errors.
-type StackTrace = pkgErr.StackTrace
-
-// Frame is the type of a single call frame entry.
-// This mirrors the type of the same name in github.com/pkg/errors.
-type Frame = pkgErr.Frame
 
 // stack represents a stack of program counters.
 // This mirrors the (non-exported) type of the same name in github.com/pkg/errors.
@@ -40,7 +32,7 @@ func (s *stack) Format(st fmt.State, verb rune) {
 		switch {
 		case st.Flag('+'):
 			for _, pc := range *s {
-				f := Frame(pc)
+				f := errbase.StackFrame(pc)
 				fmt.Fprintf(st, "\n%+v", f)
 			}
 		}
@@ -48,10 +40,10 @@ func (s *stack) Format(st fmt.State, verb rune) {
 }
 
 // StackTrace mirrors the code in github.com/pkg/errors.
-func (s *stack) StackTrace() StackTrace {
-	f := make([]Frame, len(*s))
+func (s *stack) StackTrace() errbase.StackTrace {
+	f := make([]errbase.StackFrame, len(*s))
 	for i := 0; i < len(f); i++ {
-		f[i] = Frame((*s)[i])
+		f[i] = errbase.StackFrame((*s)[i])
 	}
 	return f
 }

--- a/withstack/withstack.go
+++ b/withstack/withstack.go
@@ -65,12 +65,13 @@ func (w *withStack) Error() string { return w.cause.Error() }
 func (w *withStack) Cause() error  { return w.cause }
 func (w *withStack) Unwrap() error { return w.cause }
 
+// Format implements the fmt.Formatter interface.
 func (w *withStack) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withStack) FormatError(p errbase.Printer) error {
-	if p.Detail() {
-		p.Printf("error with attached stack trace:%+v", w.stack)
-	}
+	p.Print("attached stack trace")
+	// We do not print the stack trace ourselves - errbase.FormatError()
+	// does this for us.
 	return w.cause
 }
 


### PR DESCRIPTION
Fixes #23.

The previous code was erring towards maximizing code and interface
reuse from the `xerrors` package. That was done prior to the release
of Go 1.13, back when all the formatting principles of `xerrors` were
planned for inclusion in Go 1.13.

Then Go 1.13 was released and the formatting code in `xerrors` was
trashed withouyt making it to Go 1.13: it was imperfect.

Among the imperfections:

- it was peeling the message strings bit by bit.
  This is confusing: the full text of the error (as would be
  printed by `%s` / `.Error()`) had to be re-constructed manually.
- it had a complex integration with its `Printer` interface, due to the
  complex interplay between the `Detail()` method and the `Print()`
  methods.

Additionally, experience with this `errors` library revealed the
following additional imperfections:

- when an error object travels through application layers, it collects
  multiple stack traces. Printing every stack trace in full results in
  large amounts of redundant information. In fact, in the common case
  the stack trace in an outer layer of wrapping is a suffix of the stack
  trace(s) in the inner layers.
- the intermediate layers of "safe details" are, by design,
  repeating the "safe" (redacted) subset of information available
  in other parts of an error stack. While the *existence* of
  such a layer may be relevant, there is no need to display
  its contents with `%+v` - it does not add anything that
  the remainder of the error doesn't already reveal.
- the hidden cause behind a barrier error, if it was not provided
  by this library, would not be displayed with details
  when printed with `%+v`.

This patch follows up on these various observations by changing
`errors.FormatError` used for `%+v` formatting as follows:

- it prints out the full text of the error (as per `.Error()`) on
  the first line of output.
- it elides repeated entries in displayed stack traces.
- it omits the details contained in "safe details" layers.
- it properly reveals the structure of the hidden cause of
  barrier errors.

Additionally, it now prints out the Go type of the error layers at the
end for each numbered line of details. This has two purposes:

- it eases the troubleshooting of faulty error type comparisons or
  tests using `errors.Is` / `errors.As`.
- it makes it possible to reduce the verbosity of the
  output when printing errors with similarly structured
  payload, e.g. issue links and unimplemented errors.

This change also implies that `%+v` no longers reveals _all_ the
details of an error chain. This is deemed acceptable: these details
can be revealed otherwise by using e.g. `pretty.Formatter()` from
package `github.com/kr/pretty`.

Here is an example. Consider the following Go code:
```go
	err := errors.New("coffee")
	err = errors.Wrap(err, "delicious")
	err = errors.NewAssertionErrorWithWrappedErrf(err, "bitter")
	fmt.Printf("%+v\n", err)
```

Before this patch:
```
assertion failure
  - error with attached stack trace:
    main.main
        /data/home/kena/src/go/src/github.com/cockroachdb/cockroach/t/test.go:12
    runtime.main
        /usr/local/go/src/runtime/proc.go:203
    runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1357
  - error with embedded safe details: bitter
  - bitter:
  - delicious: coffee:
    original cause behind barrier: error with attached stack trace:
        main.main
                /data/home/kena/src/go/src/github.com/cockroachdb/cockroach/t/test.go:11
        runtime.main
                /usr/local/go/src/runtime/proc.go:203
        runtime.goexit
                /usr/local/go/src/runtime/asm_amd64.s:1357
      - delicious:
      - error with attached stack trace:
        main.main
                /data/home/kena/src/go/src/github.com/cockroachdb/cockroach/t/test.go:10
        runtime.main
                /usr/local/go/src/runtime/proc.go:203
        runtime.goexit
                /usr/local/go/src/runtime/asm_amd64.s:1357
      - coffee
```

Notice the defects:
- the words of the message ("bitter", "delicious", "coffee") are
  far apart.
- the stack trace is repeated three times.
- the safe detail part repeats a word that's already there.

After this patch:
```
bitter: delicious: coffee
(1) assertion failure
Wraps: (2) attached stack trace
  | main.main
  |     /data/home/kena/src/t/test.go:12
  | runtime.main
  |     /usr/local/go/src/runtime/proc.go:203
  | runtime.goexit
  |     /usr/local/go/src/runtime/asm_amd64.s:1357
Wraps: (3) 1 safe detail enclosed
Wraps: (4) bitter
Wraps: (5) delicious: coffee
  | -- cause hidden behind barrier
  | delicious: coffee
  | (1) attached stack trace
  |   | main.main
  |   |         /data/home/kena/src/t/test.go:11
  |   | [...repeated from below...]
  | Wraps: (2) delicious
  | Wraps: (3) attached stack trace
  |   | main.main
  |   |         /data/home/kena/src/t/test.go:10
  |   | runtime.main
  |   |         /usr/local/go/src/runtime/proc.go:203
  |   | runtime.goexit
  |   |         /usr/local/go/src/runtime/asm_amd64.s:1357
  | Wraps: (4) coffee
  | Error types: (1) *withstack.withStack (2) *errutil.withMessage (3) *withstack.withStack (4) *errors.errorString
Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *safedetails.withSafeDetails (4) *errutil.withMessage (5) *barriers.barrierError
```

- the complete message is emitted at the top.
- the types are spelled out, which eases understanding type
  comparisons and error marks.
- the safe details are omitted
- the stack traces are reduced.
  (Note: the stack trace out of a barrier cannot
  be reduced using the info from "inside" the barrier
  because what's inside the barrier is hidden to the
  outside formatter.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/26)
<!-- Reviewable:end -->
