### PR TITLE
Fix the implementation of FormatError

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -78,7 +78,9 @@ func (w *withAssertionFailure) Unwrap() error { return w.cause }
 
 func (w *withAssertionFailure) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 func (w *withAssertionFailure) FormatError(p errbase.Printer) error {
-	p.Print("assertion failure")
+	if p.Detail() {
+		p.Print("assertion failure")
+	}
 	return w.cause
 }
 

--- a/contexttags/with_context.go
+++ b/contexttags/with_context.go
@@ -53,7 +53,7 @@ func (w *withContext) Unwrap() error { return w.cause }
 func (w *withContext) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withContext) FormatError(p errbase.Printer) error {
-	if w.tags != nil {
+	if p.Detail() && w.tags != nil {
 		p.Printf("tags: [%s]", w.tags.String())
 	}
 	return w.cause

--- a/domains/with_domain.go
+++ b/domains/with_domain.go
@@ -59,7 +59,9 @@ func (e *withDomain) SafeDetails() []string {
 func (e *withDomain) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
 
 func (e *withDomain) FormatError(p errbase.Printer) error {
-	p.Print(e.domain)
+	if p.Detail() {
+		p.Print(e.domain)
+	}
 	return e.cause
 }
 

--- a/errbase/format_error.go
+++ b/errbase/format_error.go
@@ -61,7 +61,7 @@ func FormatError(err error, s fmt.State, verb rune) {
 		// to enable stack trace de-duplication. This requires a
 		// post-order traversal. Since we have a linked list, the best we
 		// can do is a recursion.
-		p.formatRecursive(err, true /* isOutermost */)
+		p.formatRecursive(err, true /* isOutermost */, true /* withDetail */)
 
 		// We now have all the data, we can render the result.
 		p.formatEntries(err)
@@ -86,7 +86,14 @@ func FormatError(err error, s fmt.State, verb rune) {
 		// instructions to obey in the final rendering or
 		// quotes to add (for %q).
 		//
-		p.buf.WriteString(err.Error())
+		// Conceptually, we could just do
+		//       p.buf.WriteString(err.Error())
+		// However we also advertise that Error() can be implemented
+		// by calling FormatError(), in which case we'd get an infinite
+		// recursion. So we have no choice but to peel the data
+		// and then assemble the pieces ourselves.
+		p.formatRecursive(err, true /* isOutermost */, false /* withDetail */)
+		p.formatSingleLineOutput()
 		p.finishDisplay(verb)
 
 	default:
@@ -106,22 +113,14 @@ func FormatError(err error, s fmt.State, verb rune) {
 	}
 }
 
-func needSpaceAtBeginning(buf []byte) bool {
-	return len(buf) > 0 && buf[0] != '\n'
-}
-
 func (s *state) formatEntries(err error) {
 	// The first entry at the top is special. We format it as follows:
 	//
 	//   <complete error message>
 	//   (1) <details>
-	s.buf.WriteString(err.Error())
+	s.formatSingleLineOutput()
 	s.buf.WriteString("\n(1)")
-	firstEntry := s.entries[len(s.entries)-1].buf
-	if needSpaceAtBeginning(firstEntry) {
-		s.buf.WriteByte(' ')
-	}
-	s.buf.Write(firstEntry)
+	printEntry(&s.buf, s.entries[len(s.entries)-1])
 
 	// All the entries that follow are printed as follows:
 	//
@@ -129,11 +128,8 @@ func (s *state) formatEntries(err error) {
 	//
 	for i, j := len(s.entries)-2, 2; i >= 0; i, j = i-1, j+1 {
 		fmt.Fprintf(&s.buf, "\nWraps: (%d)", j)
-		thisEntry := s.entries[i].buf
-		if needSpaceAtBeginning(thisEntry) {
-			s.buf.WriteByte(' ')
-		}
-		s.buf.Write(thisEntry)
+		entry := s.entries[i]
+		printEntry(&s.buf, entry)
 	}
 
 	// At the end, we link all the (N) references to the Go type of the
@@ -144,25 +140,78 @@ func (s *state) formatEntries(err error) {
 	}
 }
 
-// formatRecursive performs a post-order traversal to
-// prints errors from innermost to outermost.
-func (s *state) formatRecursive(err error, isOutermost bool) {
+func printEntry(buf *bytes.Buffer, entry formatEntry) {
+	if len(entry.head) > 0 {
+		if entry.head[0] != '\n' {
+			buf.WriteByte(' ')
+		}
+		buf.Write(entry.head)
+	}
+	if len(entry.details) > 0 {
+		if len(entry.head) == 0 {
+			if entry.details[0] != '\n' {
+				buf.WriteByte(' ')
+			}
+		}
+		buf.Write(entry.details)
+	}
+}
+
+// formatSingleLineOutput prints the details extracted via
+// formatRecursive() through the chain of errors as if .Error() has
+// been called: it only prints the non-detail parts and prints them on
+// one line with ": " separators.
+//
+// This function is used both when FormatError() is called indirectly
+// from .Error(), e.g. in:
+//      (e *myType) Error() { return fmt.Sprintf("%v", e) }
+//      (e *myType) Format(s fmt.State, verb rune) { errors.FormatError(s, verb, e) }
+//
+// and also to print the first line in the output of a %+v format.
+func (s *state) formatSingleLineOutput() {
+	for i := len(s.entries) - 1; i >= 0; i-- {
+		entry := &s.entries[i]
+		if entry.elideShort {
+			continue
+		}
+		if s.buf.Len() > 0 && len(entry.head) > 0 {
+			s.buf.WriteString(": ")
+		}
+		s.buf.Write(entry.head)
+	}
+}
+
+// formatRecursive performs a post-order traversal on the chain of
+// errors to collect error details from innermost to outermost.
+//
+// It populates s.entries as a result.
+func (s *state) formatRecursive(err error, isOutermost, withDetail bool) {
 	cause := UnwrapOnce(err)
 	if cause != nil {
 		// Recurse first.
-		s.formatRecursive(cause, false /*isOutermost*/)
+		s.formatRecursive(cause, false /*isOutermost*/, withDetail)
 	}
 
+	// Reinitialize the state for this stage of wrapping.
+	s.wantDetail = withDetail
 	s.needSpace = false
 	s.needNewline = 0
 	s.multiLine = false
 	s.notEmpty = false
+	s.hasDetail = false
+	s.headBuf = nil
 
 	seenTrace := false
 
 	switch v := err.(type) {
 	case Formatter:
-		_ = v.FormatError((*printer)(s))
+		desiredShortening := v.FormatError((*printer)(s))
+		if desiredShortening == nil {
+			// The error wants to elide the short messages. Do it.
+			for i := range s.entries {
+				s.entries[i].elideShort = true
+			}
+		}
 	case fmt.Formatter:
 		// We can only use a fmt.Formatter when both the following
 		// conditions are true:
@@ -194,22 +243,53 @@ func (s *state) formatRecursive(err error, isOutermost bool) {
 	// This will get either a stack from pkg/errors, or ours.
 	if !seenTrace {
 		if st, ok := err.(StackTraceProvider); ok {
-			if s.multiLine {
-				s.Write([]byte("\n-- stack trace:"))
-			}
 			newStack, elided := ElideSharedStackTraceSuffix(s.lastStack, st.StackTrace())
 			s.lastStack = newStack
-			newStack.Format(s, 'v')
-			if elided {
-				s.Write([]byte("\n[...repeated from below...]"))
+			if s.wantDetail {
+				s.switchOver()
+				if s.multiLine {
+					s.Write([]byte("\n-- stack trace:"))
+				}
+				newStack.Format(s, 'v')
+				if elided {
+					s.Write([]byte("\n[...repeated from below...]"))
+				}
 			}
 		}
 	}
 
-	s.entries = append(s.entries, formatEntry{err: err, buf: s.buf.Bytes()})
+	// Collect the result.
+	entry := s.collectEntry(err)
+	s.entries = append(s.entries, entry)
 	s.buf = bytes.Buffer{}
 }
 
+func (s *state) collectEntry(err error) formatEntry {
+	entry := formatEntry{err: err}
+	if s.wantDetail {
+		// The buffer has been populated as a result of formatting with
+		// %+v. In that case, if the printer has separated detail
+		// from non-detail, we can use the split.
+		if s.hasDetail {
+			entry.head = s.headBuf
+			entry.details = s.buf.Bytes()
+		} else {
+			entry.head = s.buf.Bytes()
+		}
+	} else {
+		entry.head = s.headBuf
+		if len(entry.head) > 0 && entry.head[len(entry.head)-1] != '\n' &&
+			s.buf.Len() > 0 && s.buf.Bytes()[0] != '\n' {
+			entry.head = append(entry.head, '\n')
+		}
+		entry.head = append(entry.head, s.buf.Bytes()...)
+	}
+	return entry
+}
+
+// formatSimple performs a best effort at extracting the details at a
+// given level of wrapping when the error object does not implement
+// the Formatter interface.
 func (s *state) formatSimple(err, cause error) {
 	var pref string
 	if cause != nil {
@@ -267,39 +347,118 @@ var detailSep = []byte("\n  | ")
 // state tracks error printing state. It implements fmt.State.
 type state struct {
 	fmt.State
-	buf     bytes.Buffer
+
+	// buf collects the details of the current error object
+	// at a given stage of recursion in formatRecursive().
+	// At each stage of recursion (level of wrapping), buf
+	// contains successively:
+	//
+	// - at the beginning, the "simple" part of the error message --
+	//   either the pre-Detail() string if the error implements Formatter,
+	//   or the result of Error().
+	//
+	// - after the first call to Detail(), buf is copied to headBuf,
+	//   then reset, then starts collecting the "advanced" part of the
+	//   error message.
+	buf bytes.Buffer
+	// When an error's FormatError() calls Detail(), the current
+	// value of buf above is copied to headBuf, and a new
+	// buf is initialized.
+	headBuf []byte
+	// entries collects the result of formatRecursive().
 	entries []formatEntry
 
-	lastStack   StackTrace
-	notEmpty    bool
-	needSpace   bool
+	// hasDetail becomes true at each level of th formatRecursive()
+	// recursion after the first call to .Detail(). It is used to
+	// determine how to translate buf/headBuf into a formatEntry.
+	hasDetail bool
+
+	// wantDetail is set to true when the error is formatted via %+v.
+	// When false, printer.Detail() will always return false and the
+	// error's .FormatError() method can perform less work. (This is an
+	// optimization for the common case when an error's .Error() method
+	// delegates its work to its .FormatError() via fmt.Format and
+	// errors.FormatError().)
+	wantDetail bool
+
+	// lastStack tracks the last stack trace observed when looking at
+	// the errors from innermost to outermost. This is used to elide
+	// redundant stack trace entries.
+	lastStack StackTrace
+
+	// notEmpty tracks, at each level of recursion of formatRecursive(),
+	// whether there were any details printed by an error's
+	// .FormatError() method. It is used to properly determine whether
+	// the printout should start with a newline and padding.
+	notEmpty bool
+	// needSpace tracks whether the next character displayed should pad
+	// using a space character.
+	needSpace bool
+	// needNewline tracks whether the next character displayed should
+	// pad using a newline and indentation.
 	needNewline int
-	multiLine   bool
+	// multiLine tracks whether the details so far contain multiple
+	// lines. It is used to determine whether an enclosed stack trace,
+	// if any, should be introduced with a separator.
+	multiLine bool
 }
 
+// formatEntry collects the textual details about one level of
+// wrapping or the leaf error in an error chain.
 type formatEntry struct {
 	err error
-	buf []byte
+	// head is the part of the text that is suitable for printing in the
+	// one-liner summary, or when producing the output of .Error().
+	head []byte
+	// details is the part of the text produced in the advanced output
+	// included for `%+v` formats.
+	details []byte
+	// elideShort, if true, elides the value of 'head' from concatenated
+	// "short" messages produced by formatSingleLineOutput().
+	elideShort bool
 }
 
+// String is used for debugging only.
+func (e formatEntry) String() string {
+	return fmt.Sprintf("formatEntry{%T, %q, %q}", e.err, e.head, e.details)
+}
+
+// Write implements io.Writer.
 func (s *state) Write(b []byte) (n int, err error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
 	k := 0
+
+	sep := detailSep
+	if !s.wantDetail {
+		sep = []byte("\n")
+	}
+
 	for i, c := range b {
 		if c == '\n' {
+			// Flush all the bytes seen so far.
 			s.buf.Write(b[k:i])
+			// Don't print the newline itself; instead, prepare the state so
+			// that the _next_ character encountered will pad with a newline.
+			// This algorithm avoids terminating error details with excess
+			// newline characters.
 			k = i + 1
 			s.needNewline++
 			s.needSpace = false
 			s.multiLine = true
+			if s.wantDetail {
+				s.switchOver()
+			}
 		} else {
 			if s.needNewline > 0 && s.notEmpty {
+				// If newline chars were pending, display them now.
+				// The s.notEmpty condition ensures that we don't
+				// start a detail string with excess newline characters.
 				for i := 0; i < s.needNewline-1; i++ {
-					s.buf.Write(detailSep[:len(detailSep)-1])
+					s.buf.Write(detailSep[:len(sep)-1])
 				}
-				s.buf.Write(detailSep)
+				s.buf.Write(sep)
 				s.needNewline = 0
 				s.needSpace = false
 			} else if s.needSpace {
@@ -316,10 +475,29 @@ func (s *state) Write(b []byte) (n int, err error) {
 // printer wraps a state to implement an xerrors.Printer.
 type printer state
 
-func (s *printer) Detail() bool {
-	s.needNewline = 1
-	s.notEmpty = false
+func (p *state) detail() bool {
+	if !p.wantDetail {
+		return false
+	}
+	if p.notEmpty {
+		p.needNewline = 1
+	}
+	p.switchOver()
 	return true
+}
+
+func (p *state) switchOver() {
+	if p.hasDetail {
+		return
+	}
+	p.headBuf = p.buf.Bytes()
+	p.buf = bytes.Buffer{}
+	p.notEmpty = false
+	p.hasDetail = true
+}
+
+func (s *printer) Detail() bool {
+	return ((*state)(s)).detail()
 }
 
 func (s *printer) Print(args ...interface{}) {

--- a/errbase/format_error_test.go
+++ b/errbase/format_error_test.go
@@ -109,6 +109,8 @@ func TestFormat(t *testing.T) {
 
 	ctx := context.Background()
 	const woo = `woo`
+	const waa = `waa`
+	const mwoo = "woo\nother"
 	const waawoo = `waa: woo`
 	const wuuwaawoo = `wuu: waa: woo`
 	testCases := []struct {
@@ -123,26 +125,42 @@ func TestFormat(t *testing.T) {
 		// specific case.
 		expFmtQuote string
 	}{
-		{"nofmt leaf", &errNoFmt{"woo"}, woo, woo, ``},
+		{"nofmt leaf", &errNoFmt{woo}, woo, woo, ``},
+		{"nofmt leaf multiline", &errNoFmt{mwoo}, mwoo, mwoo, ``},
 
-		{"fmt-old leaf",
-			&errFmto{"woo"},
-			woo, `
+		{"fmt-old leaf", &errFmto{woo}, woo, `
 woo
 -- this is woo's
 multi-line payload`, ``,
 		},
 
+		{"fmt-old leaf multiline", &errFmto{mwoo}, mwoo, `
+woo
+other
+-- this is woo
+other's
+multi-line payload`, ``,
+		},
+
 		{"fmt-partial leaf",
-			&errFmtp{"woo"},
+			&errFmtp{woo},
 			woo, `
 woo
 (1) woo
 Error types: (1) *errbase_test.errFmtp`, ``,
 		},
 
+		{"fmt-partial leaf multiline",
+			&errFmtp{mwoo},
+			mwoo, `
+woo
+(1) woo
+  | other
+Error types: (1) *errbase_test.errFmtp`, ``,
+		},
+
 		{"fmt leaf",
-			&errFmt{"woo"},
+			&errFmt{woo},
 			woo, `
 woo
 (1) woo
@@ -151,12 +169,24 @@ woo
 Error types: (1) *errbase_test.errFmt`, ``,
 		},
 
+		{"fmt leaf multiline",
+			&errFmt{mwoo},
+			mwoo, `
+woo
+(1) woo
+  | other
+  | -- this is woo
+  | other's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.errFmt`, ``,
+		},
+
 		{"nofmt leaf + nofmt wrap",
-			&werrNoFmt{&errNoFmt{"woo"}, "waa"},
+			&werrNoFmt{&errNoFmt{woo}, waa},
 			waawoo, waawoo, ``},
 
 		{"nofmt leaf + fmt-old wrap",
-			&werrFmto{&errNoFmt{"woo"}, "waa"},
+			&werrFmto{&errNoFmt{woo}, waa},
 			waawoo, `
 woo
 -- this is waa's
@@ -164,7 +194,7 @@ multi-line payload (fmt)`, ``,
 		},
 
 		{"nofmt leaf + fmt-partial wrap",
-			&werrFmtp{&errNoFmt{"woo"}, "waa"},
+			&werrFmtp{&errNoFmt{woo}, waa},
 			waawoo, `
 waa: woo
 (1) waa
@@ -173,7 +203,7 @@ Error types: (1) *errbase_test.werrFmtp (2) *errbase_test.errNoFmt`, ``,
 		},
 
 		{"nofmt leaf + fmt wrap",
-			&werrFmt{&errNoFmt{"woo"}, "waa"},
+			&werrFmt{&errNoFmt{woo}, waa},
 			waawoo, `
 waa: woo
 (1) waa
@@ -184,11 +214,11 @@ Error types: (1) *errbase_test.werrFmt (2) *errbase_test.errNoFmt`, ``,
 		},
 
 		{"fmt-old leaf + nofmt wrap",
-			&werrNoFmt{&errFmto{"woo"}, "waa"},
+			&werrNoFmt{&errFmto{woo}, waa},
 			waawoo, waawoo, ``},
 
 		{"fmt-old leaf + fmt-old wrap",
-			&werrFmto{&errFmto{"woo"}, "waa"},
+			&werrFmto{&errFmto{woo}, waa},
 			waawoo, `
 woo
 -- this is woo's
@@ -198,7 +228,7 @@ multi-line payload (fmt)`, ``,
 		},
 
 		{"fmt-old leaf + fmt-partial wrap",
-			&werrFmtp{&errFmto{"woo"}, "waa"},
+			&werrFmtp{&errFmto{woo}, waa},
 			waawoo, `
 waa: woo
 (1) waa
@@ -209,7 +239,7 @@ Error types: (1) *errbase_test.werrFmtp (2) *errbase_test.errFmto`, ``,
 		},
 
 		{"fmt-old leaf + fmt wrap",
-			&werrFmt{&errFmto{"woo"}, "waa"},
+			&werrFmt{&errFmto{woo}, waa},
 			waawoo, `
 waa: woo
 (1) waa
@@ -222,11 +252,11 @@ Error types: (1) *errbase_test.werrFmt (2) *errbase_test.errFmto`, ``,
 		},
 
 		{"fmt-partial leaf + nofmt wrap",
-			&werrNoFmt{&errFmtp{"woo"}, "waa"},
+			&werrNoFmt{&errFmtp{woo}, waa},
 			waawoo, waawoo, ``},
 
 		{"fmt-partial leaf + fmt-old wrap",
-			&werrFmto{&errFmtp{"woo"}, "waa"},
+			&werrFmto{&errFmtp{woo}, waa},
 			waawoo, `
 woo
 (1) woo
@@ -236,7 +266,7 @@ multi-line payload (fmt)`, ``,
 		},
 
 		{"fmt-partial leaf + fmt-partial wrap",
-			&werrFmtp{&errFmtp{"woo"}, "waa"},
+			&werrFmtp{&errFmtp{woo}, waa},
 			waawoo, `
 waa: woo
 (1) waa
@@ -247,7 +277,7 @@ Error types: (1) *errbase_test.werrFmtp (2) *errbase_test.errFmtp`, ``,
 		},
 
 		{"fmt-partial leaf + fmt wrap",
-			&werrFmt{&errFmtp{"woo"}, "waa"},
+			&werrFmt{&errFmtp{woo}, waa},
 			waawoo, `
 waa: woo
 (1) waa
@@ -260,11 +290,11 @@ Error types: (1) *errbase_test.werrFmt (2) *errbase_test.errFmtp`, ``,
 		},
 
 		{"fmt leaf + nofmt wrap",
-			&werrNoFmt{&errFmt{"woo"}, "waa"},
+			&werrNoFmt{&errFmt{woo}, waa},
 			waawoo, waawoo, ``},
 
 		{"fmt leaf + fmt-old wrap",
-			&werrFmto{&errFmt{"woo"}, "waa"},
+			&werrFmto{&errFmt{woo}, waa},
 			waawoo, `
 woo
 (1) woo
@@ -276,7 +306,7 @@ multi-line payload (fmt)`, ``,
 		},
 
 		{"fmt leaf + fmt-partial wrap",
-			&werrFmtp{&errFmt{"woo"}, "waa"},
+			&werrFmtp{&errFmt{woo}, waa},
 			waawoo, `
 waa: woo
 (1) waa
@@ -287,7 +317,7 @@ Error types: (1) *errbase_test.werrFmtp (2) *errbase_test.errFmt`, ``,
 		},
 
 		{"fmt leaf + fmt wrap",
-			&werrFmt{&errFmt{"woo"}, "waa"},
+			&werrFmt{&errFmt{woo}, waa},
 			waawoo, `
 waa: woo
 (1) waa
@@ -300,11 +330,11 @@ Error types: (1) *errbase_test.werrFmt (2) *errbase_test.errFmt`, ``,
 		},
 
 		{"nofmt wrap in + nofmt wrap out",
-			&werrNoFmt{&werrNoFmt{&errFmt{"woo"}, "waa"}, "wuu"},
+			&werrNoFmt{&werrNoFmt{&errFmt{woo}, waa}, "wuu"},
 			wuuwaawoo, wuuwaawoo, ``},
 
 		{"nofmt wrap in + fmd-old wrap out",
-			&werrFmto{&werrNoFmt{&errFmt{"woo"}, "waa"}, "wuu"},
+			&werrFmto{&werrNoFmt{&errFmt{woo}, waa}, "wuu"},
 			wuuwaawoo, `
 waa: woo
 -- this is wuu's
@@ -312,7 +342,7 @@ multi-line payload (fmt)`, ``,
 		},
 
 		{"nofmt wrap in + fmt wrap out",
-			&werrFmt{&werrNoFmt{&errFmt{"woo"}, "waa"}, "wuu"},
+			&werrFmt{&werrNoFmt{&errFmt{woo}, waa}, "wuu"},
 			wuuwaawoo, `
 wuu: waa: woo
 (1) wuu
@@ -326,11 +356,11 @@ Error types: (1) *errbase_test.werrFmt (2) *errbase_test.werrNoFmt (3) *errbase_
 		},
 
 		{"fmt-old wrap in + nofmt wrap out",
-			&werrNoFmt{&werrFmto{&errFmt{"woo"}, "waa"}, "wuu"},
+			&werrNoFmt{&werrFmto{&errFmt{woo}, waa}, "wuu"},
 			wuuwaawoo, wuuwaawoo, ``},
 
 		{"fmt-old wrap in + fmd-old wrap out",
-			&werrFmto{&werrFmto{&errFmt{"woo"}, "waa"}, "wuu"},
+			&werrFmto{&werrFmto{&errFmt{woo}, waa}, "wuu"},
 			wuuwaawoo, `
 woo
 (1) woo
@@ -344,7 +374,7 @@ multi-line payload (fmt)`, ``,
 		},
 
 		{"fmt-old wrap in + fmt wrap out",
-			&werrFmt{&werrFmto{&errFmt{"woo"}, "waa"}, "wuu"},
+			&werrFmt{&werrFmto{&errFmt{woo}, waa}, "wuu"},
 			wuuwaawoo, `
 wuu: waa: woo
 (1) wuu
@@ -358,11 +388,11 @@ Error types: (1) *errbase_test.werrFmt (2) *errbase_test.werrFmto (3) *errbase_t
 		},
 
 		{"fmt wrap in + nofmt wrap out",
-			&werrNoFmt{&werrFmt{&errFmt{"woo"}, "waa"}, "wuu"},
+			&werrNoFmt{&werrFmt{&errFmt{woo}, waa}, "wuu"},
 			wuuwaawoo, wuuwaawoo, ``},
 
 		{"fmt wrap in + fmd-old wrap out",
-			&werrFmto{&werrFmt{&errFmt{"woo"}, "waa"}, "wuu"},
+			&werrFmto{&werrFmt{&errFmt{woo}, waa}, "wuu"},
 			wuuwaawoo, `
 waa: woo
 (1) waa
@@ -377,7 +407,7 @@ multi-line payload (fmt)`, ``,
 		},
 
 		{"fmt wrap in + fmt wrap out",
-			&werrFmt{&werrFmt{&errFmt{"woo"}, "waa"}, "wuu"},
+			&werrFmt{&werrFmt{&errFmt{woo}, waa}, "wuu"},
 			wuuwaawoo, `
 wuu: waa: woo
 (1) wuu
@@ -394,7 +424,7 @@ Error types: (1) *errbase_test.werrFmt (2) *errbase_test.werrFmt (3) *errbase_te
 
 		// Opaque leaf.
 		{"opaque leaf",
-			errbase.DecodeError(ctx, errbase.EncodeError(ctx, &errNoFmt{"woo"})),
+			errbase.DecodeError(ctx, errbase.EncodeError(ctx, &errNoFmt{woo})),
 			woo, `
 woo
 (1) woo
@@ -405,7 +435,7 @@ Error types: (1) *errbase.opaqueLeaf`, ``},
 
 		// Opaque wrapper.
 		{"opaque wrapper",
-			errbase.DecodeError(ctx, errbase.EncodeError(ctx, &werrNoFmt{goErr.New("woo"), "waa"})),
+			errbase.DecodeError(ctx, errbase.EncodeError(ctx, &werrNoFmt{goErr.New(woo), waa})),
 			waawoo, `
 waa: woo
 (1) waa
@@ -416,7 +446,7 @@ Wraps: (2) woo
 Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString`, ``},
 
 		{"opaque wrapper+wrapper",
-			errbase.DecodeError(ctx, errbase.EncodeError(ctx, &werrNoFmt{&werrNoFmt{goErr.New("woo"), "waa"}, "wuu"})),
+			errbase.DecodeError(ctx, errbase.EncodeError(ctx, &werrNoFmt{&werrNoFmt{goErr.New(woo), waa}, "wuu"})),
 			wuuwaawoo, `
 wuu: waa: woo
 (1) wuu
@@ -433,7 +463,7 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errors.e
 		// Compatibility with github.com/pkg/errors.
 
 		{"pkg msg + fmt leaf",
-			pkgErr.WithMessage(&errFmt{"woo"}, "waa"),
+			pkgErr.WithMessage(&errFmt{woo}, waa),
 			waawoo, `
 woo
 (1) woo
@@ -446,7 +476,7 @@ waa`,
 		},
 
 		{"fmt wrap + pkg msg + fmt leaf",
-			&werrFmt{pkgErr.WithMessage(&errFmt{"woo"}, "waa"), "wuu"},
+			&werrFmt{pkgErr.WithMessage(&errFmt{woo}, waa), "wuu"},
 			wuuwaawoo, `
 wuu: waa: woo
 (1) wuu
@@ -463,7 +493,7 @@ Error types: (1) *errbase_test.werrFmt (2) *errors.withMessage (3) *errbase_test
 			&werrFmt{
 				pkgErr.WithMessage(
 					pkgErr.WithMessage(
-						&errFmt{"woo"}, "waa2"),
+						&errFmt{woo}, "waa2"),
 					"waa1"),
 				"wuu"},
 			`wuu: waa1: waa2: woo`, `
@@ -480,7 +510,7 @@ Error types: (1) *errbase_test.werrFmt (2) *errors.withMessage (3) *errors.withM
 		},
 
 		{"fmt wrap + pkg stack + fmt leaf",
-			&werrFmt{pkgErr.WithStack(&errFmt{"woo"}), "waa"},
+			&werrFmt{pkgErr.WithStack(&errFmt{woo}), waa},
 			waawoo, `
 waa: woo
 (1) waa
@@ -498,6 +528,103 @@ Wraps: (3) woo
   | multi-line leaf payload
 Error types: (1) *errbase_test.werrFmt (2) *errors.withStack (3) *errbase_test.errFmt`, ``,
 		},
+
+		{"delegating wrap",
+			&werrDelegate{&errNoFmt{woo}}, "prefix: woo", `
+prefix: woo
+(1) prefix
+  | -- multi-line
+  | wrapper payload
+Wraps: (2) woo
+Error types: (1) *errbase_test.werrDelegate (2) *errbase_test.errNoFmt`, ``,
+		},
+
+		{"delegating wrap + pkg stack + fmt leaf",
+			&werrDelegate{pkgErr.WithStack(&errFmt{woo})},
+			"prefix: woo", `
+prefix: woo
+(1) prefix
+  | -- multi-line
+  | wrapper payload
+Wraps: (2)
+  | github.com/cockroachdb/errors/errbase_test.TestFormat
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrDelegate (2) *errors.withStack (3) *errbase_test.errFmt`, ``,
+		},
+
+		{"empty wrap",
+			&werrEmpty{&errNoFmt{woo}}, woo, `
+woo
+(1)
+Wraps: (2) woo
+Error types: (1) *errbase_test.werrEmpty (2) *errbase_test.errNoFmt`, ``,
+		},
+
+		{"empty wrap + pkg stack + fmt leaf",
+			&werrEmpty{pkgErr.WithStack(&errFmt{woo})},
+			woo, `
+woo
+(1)
+Wraps: (2)
+  | github.com/cockroachdb/errors/errbase_test.TestFormat
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrEmpty (2) *errors.withStack (3) *errbase_test.errFmt`, ``,
+		},
+
+		{"empty delegate wrap",
+			&werrDelegateEmpty{&errNoFmt{woo}}, woo, `
+woo
+(1)
+Wraps: (2) woo
+Error types: (1) *errbase_test.werrDelegateEmpty (2) *errbase_test.errNoFmt`, ``,
+		},
+
+		{"empty delegate wrap + pkg stack + fmt leaf",
+			&werrDelegateEmpty{pkgErr.WithStack(&errFmt{woo})},
+			woo, `
+woo
+(1)
+Wraps: (2)
+  | github.com/cockroachdb/errors/errbase_test.TestFormat
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) woo
+  | -- this is woo's
+  | multi-line leaf payload
+Error types: (1) *errbase_test.werrDelegateEmpty (2) *errors.withStack (3) *errbase_test.errFmt`, ``,
+		},
+
+		{"delegating wrap noprefix + details",
+			&werrDelegateNoPrefix{&errNoFmt{woo}}, woo, `
+woo
+(1) detail
+Wraps: (2) woo
+Error types: (1) *errbase_test.werrDelegateNoPrefix (2) *errbase_test.errNoFmt`, ``,
+		},
+
+		{"wrapper with truncated short msg",
+			&werrWithElidedCause{&errNoFmt{woo}},
+			"overridden message", `overridden message
+(1) overridden message
+Wraps: (2) woo
+Error types: (1) *errbase_test.werrWithElidedCause (2) *errbase_test.errNoFmt`, ``},
 	}
 
 	for _, test := range testCases {
@@ -570,6 +697,25 @@ func (e *errFmto) Format(s fmt.State, verb rune) {
 	}
 }
 
+// errFmtoDelegate is like errFmto but the Error() method delegates to
+// Format().
+type errFmtoDelegate struct{ msg string }
+
+func (e *errFmtoDelegate) Error() string { return fmt.Sprintf("%v", e) }
+func (e *errFmtoDelegate) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprint(s, e.msg)
+			fmt.Fprintf(s, "\n-- this is %s's\nmulti-line payload", e.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		fmt.Fprintf(s, fmt.Sprintf("%%%s%c", flags(s), verb), e.msg)
+	}
+}
+
 // werrFmto is like errFmto but is a wrapper.
 type werrFmto struct {
 	cause error
@@ -589,6 +735,29 @@ func (e *werrFmto) Format(s fmt.State, verb rune) {
 		fallthrough
 	case 's', 'q':
 		fmt.Fprintf(s, fmt.Sprintf("%%%s%c", flags(s), verb), e.Error())
+	}
+}
+
+// werrFmtoDelegate is like errFmtoDelegate but is a wrapper.
+type werrFmtoDelegate struct {
+	cause error
+	msg   string
+}
+
+func (e *werrFmtoDelegate) Error() string { return fmt.Sprintf("%v", e) }
+func (e *werrFmtoDelegate) Unwrap() error { return e.cause }
+func (e *werrFmtoDelegate) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", e.cause)
+			fmt.Fprint(s, "\n-- multi-line\npayload (fmt)")
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		fmts := fmt.Sprintf("%%%s%c", flags(s), verb)
+		fmt.Fprintf(s, fmts, e.msg+": "+e.cause.Error())
 	}
 }
 
@@ -655,4 +824,96 @@ func flags(s fmt.State) string {
 		flags += " "
 	}
 	return flags
+}
+
+// TestDelegateProtocol checks that there is no infinite recursion
+// when Error() delegates its behavior to FormatError().
+func TestDelegateProtocol(t *testing.T) {
+	tt := testutils.T{t}
+
+	var err error
+	err = &werrDelegate{&errNoFmt{"woo"}}
+	tt.CheckStringEqual(fmt.Sprintf("%v", err), "prefix: woo")
+
+	err = &werrDelegateNoPrefix{&errNoFmt{"woo"}}
+	tt.CheckStringEqual(fmt.Sprintf("%v", err), "woo")
+}
+
+// werrDelegate delegates its Error() behavior to FormatError().
+type werrDelegate struct {
+	wrapped error
+}
+
+var _ fmt.Formatter = (*werrDelegate)(nil)
+var _ errbase.Formatter = (*werrDelegate)(nil)
+
+func (e *werrDelegate) Error() string                 { return fmt.Sprintf("%v", e) }
+func (e *werrDelegate) Cause() error                  { return e.wrapped }
+func (e *werrDelegate) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
+func (e *werrDelegate) FormatError(p errbase.Printer) error {
+	p.Print("prefix")
+	if p.Detail() {
+		p.Print("-- multi-line\nwrapper payload")
+	}
+	return e.wrapped
+}
+
+// werrDelegateNoPrefix delegates its Error() behavior to FormatError()
+// via fmt.Format, has no prefix of its own in its short message
+// but has a detail field.
+type werrDelegateNoPrefix struct {
+	wrapped error
+}
+
+var _ errbase.Formatter = (*werrDelegateNoPrefix)(nil)
+var _ fmt.Formatter = (*werrDelegateNoPrefix)(nil)
+
+func (e *werrDelegateNoPrefix) Error() string                 { return fmt.Sprintf("%v", e) }
+func (e *werrDelegateNoPrefix) Cause() error                  { return e.wrapped }
+func (e *werrDelegateNoPrefix) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
+func (e *werrDelegateNoPrefix) FormatError(p errbase.Printer) error {
+	if p.Detail() {
+		p.Print("detail")
+	}
+	return e.wrapped
+}
+
+type werrDelegateEmpty struct {
+	wrapped error
+}
+
+var _ errbase.Formatter = (*werrDelegateEmpty)(nil)
+var _ fmt.Formatter = (*werrDelegateEmpty)(nil)
+
+func (e *werrDelegateEmpty) Error() string                 { return fmt.Sprintf("%v", e) }
+func (e *werrDelegateEmpty) Cause() error                  { return e.wrapped }
+func (e *werrDelegateEmpty) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
+func (e *werrDelegateEmpty) FormatError(p errbase.Printer) error {
+	return e.wrapped
+}
+
+// werrEmpty has no message of its own.
+type werrEmpty struct {
+	wrapped error
+}
+
+var _ error = (*werrEmpty)(nil)
+var _ fmt.Formatter = (*werrEmpty)(nil)
+
+func (e *werrEmpty) Error() string                 { return e.wrapped.Error() }
+func (e *werrEmpty) Cause() error                  { return e.wrapped }
+func (e *werrEmpty) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
+
+// werrWithElidedClause overrides its cause's Error() from its own
+// short message.
+type werrWithElidedCause struct {
+	wrapped error
+}
+
+func (e *werrWithElidedCause) Error() string                 { return fmt.Sprintf("%v", e) }
+func (e *werrWithElidedCause) Cause() error                  { return e.wrapped }
+func (e *werrWithElidedCause) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
+func (e *werrWithElidedCause) FormatError(p errbase.Printer) error {
+	p.Print("overridden message")
+	return nil
 }

--- a/errbase/formatter.go
+++ b/errbase/formatter.go
@@ -25,8 +25,22 @@ package errbase
 type Formatter interface {
 	error
 
-	// FormatError prints the receiver's first error and returns the next error in
-	// the error chain, if any.
+	// FormatError prints the receiver's first error.
+	// The return value decides what happens in the case
+	// FormatError() is used to produce a "short" message,
+	// eg. when it is used to implementError():
+	//
+	// - if it returns nil, then the short message
+	//   contains no more than that produced for this error,
+	//   even if the error has a further causal chain.
+	//
+	// - if it returns non-nil, then the short message
+	//   contains the value printed by this error,
+	//   followed by that of its causal chain.
+	//   (e.g. thiserror: itscause: furthercause)
+	//
+	// Note that all the causal chain is reported in verbose reports in
+	// any case.
 	FormatError(p Printer) (next error)
 }
 

--- a/extgrpc/ext_grpc_test.go
+++ b/extgrpc/ext_grpc_test.go
@@ -49,8 +49,7 @@ func TestGrpc(t *testing.T) {
 	tt.CheckStringEqual(fmt.Sprintf("%v", err), `hello`)
 	// The code appears when the error is printed verbosely.
 	tt.CheckStringEqual(fmt.Sprintf("%+v", err), `hello
-(1)
-  | gRPC code: Unavailable
+(1) gRPC code: Unavailable
 Wraps: (2) hello
 Error types: (1) *extgrpc.withGrpcCode (2) *errors.errorString`)
 

--- a/exthttp/ext_http_test.go
+++ b/exthttp/ext_http_test.go
@@ -48,8 +48,7 @@ func TestHTTP(t *testing.T) {
 	tt.CheckStringEqual(fmt.Sprintf("%v", err), `hello`)
 	// The code appears when the error is printed verbosely.
 	tt.CheckStringEqual(fmt.Sprintf("%+v", err), `hello
-(1)
-  | http code: 302
+(1) http code: 302
 Wraps: (2) hello
 Error types: (1) *exthttp.withHTTPCode (2) *errors.errorString`)
 }

--- a/hintdetail/with_detail.go
+++ b/hintdetail/with_detail.go
@@ -41,7 +41,9 @@ func (w *withDetail) Unwrap() error       { return w.cause }
 func (w *withDetail) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withDetail) FormatError(p errbase.Printer) error {
-	p.Print(w.detail)
+	if p.Detail() {
+		p.Print(w.detail)
+	}
 	return w.cause
 }
 

--- a/hintdetail/with_hint.go
+++ b/hintdetail/with_hint.go
@@ -41,7 +41,9 @@ func (w *withHint) Unwrap() error     { return w.cause }
 func (w *withHint) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withHint) FormatError(p errbase.Printer) error {
-	p.Print(w.hint)
+	if p.Detail() {
+		p.Print(w.hint)
+	}
 	return w.cause
 }
 

--- a/issuelink/unimplemented_error.go
+++ b/issuelink/unimplemented_error.go
@@ -52,12 +52,15 @@ const UnimplementedErrorHint = `You have attempted to use a feature that is not 
 func (w *unimplementedError) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *unimplementedError) FormatError(p errbase.Printer) error {
-	p.Printf("unimplemented: %s", w.msg)
-	if w.IssueURL != "" {
-		p.Printf("\nissue: %s", w.IssueURL)
-	}
-	if w.Detail != "" {
-		p.Printf("\ndetail: %s", w.Detail)
+	p.Print(w.msg)
+	if p.Detail() {
+		p.Print("unimplemented")
+		if w.IssueURL != "" {
+			p.Printf("\nissue: %s", w.IssueURL)
+		}
+		if w.Detail != "" {
+			p.Printf("\ndetail: %s", w.Detail)
+		}
 	}
 	return nil
 }

--- a/issuelink/unimplemented_test.go
+++ b/issuelink/unimplemented_test.go
@@ -76,14 +76,16 @@ func TestFormatUnimp(t *testing.T) {
 			issuelink.UnimplementedError(link, "woo"),
 			woo, `
 woo
-(1) unimplemented: woo
+(1) woo
+  | unimplemented
   | issue: http://mysite
 Error types: (1) *issuelink.unimplementedError`},
 		{"unimp-details",
 			issuelink.UnimplementedError(issuelink.IssueLink{IssueURL: "http://mysite", Detail: "see more"}, "woo"),
 			woo, `
 woo
-(1) unimplemented: woo
+(1) woo
+  | unimplemented
   | issue: http://mysite
   | detail: see more
 Error types: (1) *issuelink.unimplementedError`},
@@ -95,7 +97,8 @@ waa: woo
 (1) waa
   | -- this is waa's
   | multi-line payload
-Wraps: (2) unimplemented: woo
+Wraps: (2) woo
+  | unimplemented
   | issue: http://mysite
 Error types: (1) *issuelink_test.werrFmt (2) *issuelink.unimplementedError`},
 	}

--- a/issuelink/with_issuelink.go
+++ b/issuelink/with_issuelink.go
@@ -65,13 +65,15 @@ func maybeAppendReferral(buf *bytes.Buffer, link IssueLink) {
 func (w *withIssueLink) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withIssueLink) FormatError(p errbase.Printer) error {
-	sep := ""
-	if w.IssueURL != "" {
-		p.Printf("issue: %s", w.IssueURL)
-		sep = "\n"
-	}
-	if w.Detail != "" {
-		p.Printf("%sdetail: %s", sep, w.Detail)
+	if p.Detail() {
+		sep := ""
+		if w.IssueURL != "" {
+			p.Printf("issue: %s", w.IssueURL)
+			sep = "\n"
+		}
+		if w.Detail != "" {
+			p.Printf("%sdetail: %s", sep, w.Detail)
+		}
 	}
 	return w.cause
 }

--- a/markers/markers.go
+++ b/markers/markers.go
@@ -202,8 +202,8 @@ func (m *withMark) Unwrap() error { return m.cause }
 func (m *withMark) Format(s fmt.State, verb rune) { errbase.FormatError(m, s, verb) }
 
 func (m *withMark) FormatError(p errbase.Printer) error {
-	p.Print("forced error mark")
 	if p.Detail() {
+		p.Print("forced error mark\n")
 		p.Printf("%q\n%s::%s",
 			m.mark.msg,
 			m.mark.types[0].FamilyName,

--- a/markers/markers_test.go
+++ b/markers/markers_test.go
@@ -527,3 +527,21 @@ func (e *werrFmt) FormatError(p errbase.Printer) error {
 	}
 	return e.cause
 }
+
+func TestInvalidError(t *testing.T) {
+	tt := testutils.T{T: t}
+
+	err := &invalidError{}
+	errRef := errors.New("hello")
+	tt.Check(!markers.Is(err, errRef))
+	tt.Check(markers.Is(err, err))
+	tt.Check(markers.IsType(err, (*invalidError)(nil)))
+	tt.Check(markers.HasType(err, (*invalidError)(nil)))
+}
+
+type invalidError struct {
+	emptyRef error
+}
+
+func (e *invalidError) Error() string { return e.emptyRef.Error() }
+func (e *invalidError) Cause() error  { return e.emptyRef }

--- a/safedetails/with_safedetails.go
+++ b/safedetails/with_safedetails.go
@@ -38,11 +38,13 @@ var _ fmt.Formatter = (*withSafeDetails)(nil)
 func (e *withSafeDetails) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
 
 func (e *withSafeDetails) FormatError(p errbase.Printer) error {
-	plural := "s"
-	if len(e.safeDetails) == 1 {
-		plural = ""
+	if p.Detail() {
+		plural := "s"
+		if len(e.safeDetails) == 1 {
+			plural = ""
+		}
+		p.Printf("%d safe detail%s enclosed", len(e.safeDetails), plural)
 	}
-	p.Printf("%d safe detail%s enclosed", len(e.safeDetails), plural)
 	return e.cause
 }
 

--- a/secondary/with_secondary.go
+++ b/secondary/with_secondary.go
@@ -49,8 +49,8 @@ func (e *withSecondaryError) SafeDetails() []string {
 func (e *withSecondaryError) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
 
 func (e *withSecondaryError) FormatError(p errbase.Printer) (next error) {
-	p.Print("secondary error attachment")
 	if p.Detail() {
+		p.Print("secondary error attachment\n")
 		p.Printf("%+v", e.secondaryError)
 	}
 	return e.cause

--- a/telemetrykeys/with_telemetry.go
+++ b/telemetrykeys/with_telemetry.go
@@ -41,7 +41,9 @@ func (w *withTelemetry) SafeDetails() []string { return w.keys }
 func (w *withTelemetry) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withTelemetry) FormatError(p errbase.Printer) (next error) {
-	p.Printf("keys: %+v", w.keys)
+	if p.Detail() {
+		p.Printf("keys: %+v", w.keys)
+	}
 	return w.cause
 }
 

--- a/withstack/withstack.go
+++ b/withstack/withstack.go
@@ -69,7 +69,9 @@ func (w *withStack) Unwrap() error { return w.cause }
 func (w *withStack) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
 
 func (w *withStack) FormatError(p errbase.Printer) error {
-	p.Print("attached stack trace")
+	if p.Detail() {
+		p.Print("attached stack trace")
+	}
 	// We do not print the stack trace ourselves - errbase.FormatError()
 	// does this for us.
 	return w.cause


### PR DESCRIPTION
The previous change in this area had created major breakage: it is
possible for an error type to implement its `.Error()` method as an
indirect call to `errors.FormatError()`, via `fmt.Sprintf(`%v`, e)`
and a suitable `fmt.Formatter` implementation.

If, as introduced in the previous commit, `errors.FormatError()` in
turn calls `.Error()`, an infinite recursion occurs.

This problem did not exist in the previous code from the `xerrors`
package; in fact, some of the complexity of the original
implementation which I had considered superfluous existed precisely to
cover this case. I was not able to recognize this at the time because
the formatting tests did not include a case for this.

This commit addresses the problem and introduces the missing tests.
It also introduces a minor optimization to remove a superfluous
newline in certain cases of `%+v` formatting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/28)
<!-- Reviewable:end -->
