### PR TITLE
markers: rename IsInterface -> HasInterface

### DIFF
--- a/markers/example_is_type_test.go
+++ b/markers/example_is_type_test.go
@@ -30,18 +30,12 @@ func ExampleIsType() {
 	base := &ExampleError{"world"}
 	err := errors.Wrap(base, "hello")
 	fmt.Println(markers.HasType(err, (*ExampleError)(nil)))
-	fmt.Println(markers.IsType(err, (*ExampleError)(nil)))
 	fmt.Println(markers.HasType(err, nil))
-	fmt.Println(markers.IsType(err, nil))
 	fmt.Println(markers.HasType(err, (*net.AddrError)(nil)))
-	fmt.Println(markers.IsType(err, (*net.AddrError)(nil)))
 
 	// Output:
 	//
 	// true
-	// false
-	// false
-	// false
 	// false
 	// false
 }
@@ -52,14 +46,14 @@ func ExampleIsInterface() {
 		Err:  "ndn doesn't really exists :(",
 	}
 	err := errors.Wrap(base, "bummer")
-	fmt.Println(markers.IsInterface(err, (*net.Error)(nil)))
+	fmt.Println(markers.HasInterface(err, (*net.Error)(nil)))
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
 				fmt.Println("*net.AddrError is not a pointer to an interface type so the call panics")
 			}
 		}()
-		fmt.Println(markers.IsInterface(err, (*net.AddrError)(nil)))
+		fmt.Println(markers.HasInterface(err, (*net.AddrError)(nil)))
 	}()
 
 	// Output:

--- a/markers/markers.go
+++ b/markers/markers.go
@@ -69,27 +69,25 @@ func HasType(err error, referenceType error) bool {
 	return isType
 }
 
-// IsType returns true if the outermost err object has a concrete type
-// matching that of referenceType.
-func IsType(err error, referenceType error) bool {
-	return reflect.TypeOf(err) == reflect.TypeOf(referenceType)
-}
-
-// IsInterface returns true if err contains an error which implements the
+// HasInterface returns true if err contains an error which implements the
 // interface pointed to by referenceInterface. The type of referenceInterface
 // must be a pointer to an interface type. If referenceInterface is not a
 // pointer to an interface, this function will panic.
-func IsInterface(err error, referenceInterface interface{}) bool {
-	typ := reflect.TypeOf(referenceInterface)
-	if typ == nil || typ.Kind() != reflect.Ptr || typ.Elem().Kind() != reflect.Interface {
-		panic(fmt.Errorf("errors.IsInterface: referenceInterface must be a pointer to an interface, "+
-			"found %T", referenceInterface))
-	}
-	iface := typ.Elem()
+func HasInterface(err error, referenceInterface interface{}) bool {
+	iface := getInterfaceType("HasInterface", referenceInterface)
 	_, isType := If(err, func(err error) (interface{}, bool) {
 		return nil, reflect.TypeOf(err).Implements(iface)
 	})
 	return isType
+}
+
+func getInterfaceType(context string, referenceInterface interface{}) reflect.Type {
+	typ := reflect.TypeOf(referenceInterface)
+	if typ == nil || typ.Kind() != reflect.Ptr || typ.Elem().Kind() != reflect.Interface {
+		panic(fmt.Errorf("errors.%s: referenceInterface must be a pointer to an interface, "+
+			"found %T", context, referenceInterface))
+	}
+	return typ.Elem()
 }
 
 // If returns a predicate's return value the first time the predicate returns true.

--- a/markers/markers_test.go
+++ b/markers/markers_test.go
@@ -255,9 +255,7 @@ func TestHasType(t *testing.T) {
 	tt.Check(!markers.HasType(wrapped, nil))
 
 	tt.Check(markers.HasType(base, (*testError)(nil)))
-	tt.Check(markers.IsType(base, (*testError)(nil)))
 	tt.Check(markers.HasType(wrapped, (*testError)(nil)))
-	tt.Check(!markers.IsType(wrapped, (*testError)(nil)))
 
 	// nil errors don't contain any types, not even nil.
 	tt.Check(!markers.HasType(nil, nil))
@@ -274,11 +272,11 @@ func TestIsInterface(t *testing.T) {
 	base := &testError{msg: "hmm"}
 	wrapped := pkgErr.Wrap(base, "boom")
 
-	tt.Check(markers.IsInterface(base, (*testErrorInterface)(nil)))
-	tt.Check(markers.IsInterface(wrapped, (*testErrorInterface)(nil)))
+	tt.Check(markers.HasInterface(base, (*testErrorInterface)(nil)))
+	tt.Check(markers.HasInterface(wrapped, (*testErrorInterface)(nil)))
 
-	tt.Check(!markers.IsInterface(base, (*net.Error)(nil)))
-	tt.Check(!markers.IsInterface(wrapped, (*net.Error)(nil)))
+	tt.Check(!markers.HasInterface(base, (*net.Error)(nil)))
+	tt.Check(!markers.HasInterface(wrapped, (*net.Error)(nil)))
 }
 
 // This test is used in the RFC.
@@ -535,7 +533,6 @@ func TestInvalidError(t *testing.T) {
 	errRef := errors.New("hello")
 	tt.Check(!markers.Is(err, errRef))
 	tt.Check(markers.Is(err, err))
-	tt.Check(markers.IsType(err, (*invalidError)(nil)))
 	tt.Check(markers.HasType(err, (*invalidError)(nil)))
 }
 

--- a/markers_api.go
+++ b/markers_api.go
@@ -19,15 +19,12 @@ import "github.com/cockroachdb/errors/markers"
 // Is forwards a definition.
 func Is(err, reference error) bool { return markers.Is(err, reference) }
 
-// IsType forwards a definition.
-func IsType(err, referenceType error) bool { return markers.IsType(err, referenceType) }
-
 // HasType forwards a definition.
 func HasType(err, referenceType error) bool { return markers.HasType(err, referenceType) }
 
-// IsInterface forwards a definition.
-func IsInterface(err error, referenceInterface interface{}) bool {
-	return markers.IsInterface(err, referenceInterface)
+// HasInterface forwards a definition.
+func HasInterface(err error, referenceInterface interface{}) bool {
+	return markers.HasInterface(err, referenceInterface)
 }
 
 // If forwards a definition.


### PR DESCRIPTION
the idiom set by the go stdlib is that "Has" recurses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/29)
<!-- Reviewable:end -->
