### PR TITLE
new: errors.NewV and errors.WrapV shorthands

### DIFF
--- a/errutil/message_test.go
+++ b/errutil/message_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/errors/errbase"
 	"github.com/cockroachdb/errors/errutil"
+	"github.com/cockroachdb/errors/safedetails"
 	"github.com/cockroachdb/errors/testutils"
 )
 
@@ -126,6 +127,58 @@ Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *erro
 `,
 		},
 
+		{"newv",
+			errutil.NewV(123),
+			`123`,
+			`
+123
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (2) 2 safe details enclosed
+Wraps: (3) 123
+Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errors.errorString`,
+			`
+(0.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(1.1) -- arg 1: <int>
+`,
+		},
+
+		{"newv-safe",
+			errutil.NewV(safedetails.Safe(123)),
+			`123`,
+			`
+123
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (2) 2 safe details enclosed
+Wraps: (3) 123
+Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errors.errorString`,
+			`
+(0.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(1.1) -- arg 1: 123
+`,
+		},
+
 		{"wrapf",
 			errutil.Wrapf(goErr.New("woo"), "waa: %s", "hello"),
 			`waa: hello: woo`, `
@@ -199,6 +252,60 @@ Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *erru
       runtime.goexit
       <tab><path>
 (1.1) -- arg 1: <int>
+`,
+		},
+
+		{"wrapv",
+			errutil.WrapV(goErr.New("woo"), 123),
+			`123: woo`,
+			`
+123: woo
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (2) 2 safe details enclosed
+Wraps: (3) 123
+Wraps: (4) woo
+Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errutil.withMessage (4) *errors.errorString`,
+			`
+(0.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(1.1) -- arg 1: <int>
+`,
+		},
+
+		{"wrapv-safe",
+			errutil.WrapV(goErr.New("woo"), safedetails.Safe(123)),
+			`123: woo`,
+			`
+123: woo
+(1) attached stack trace
+  | github.com/cockroachdb/errors/errutil_test.TestFormat
+  | <tab><path>
+  | testing.tRunner
+  | <tab><path>
+  | runtime.goexit
+  | <tab><path>
+Wraps: (2) 2 safe details enclosed
+Wraps: (3) 123
+Wraps: (4) woo
+Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errutil.withMessage (4) *errors.errorString`,
+			`
+(0.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(1.1) -- arg 1: 123
 `,
 		},
 

--- a/errutil/message_test.go
+++ b/errutil/message_test.go
@@ -34,6 +34,7 @@ func TestFormat(t *testing.T) {
 		err           error
 		expFmtSimple  string
 		expFmtVerbose string
+		details       string
 	}{
 		{"fmt wrap + local msg + fmt leaf",
 			&werrFmt{
@@ -48,6 +49,7 @@ wuu: waa: woo
 Wraps: (2) waa
 Wraps: (3) woo
 Error types: (1) *errutil_test.werrFmt (2) *errutil.withMessage (3) *errors.errorString`,
+			``,
 		},
 
 		{"newf",
@@ -64,6 +66,16 @@ waa: hello
 Wraps: (2) 2 safe details enclosed
 Wraps: (3) waa: hello
 Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errors.errorString`,
+			`
+(0.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(1.0) waa: %s
+(1.1) -- arg 1: <string>
+`,
 		},
 
 		{"newf-empty",
@@ -79,6 +91,14 @@ Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *erro
   | <tab><path>
 Wraps: (2)
 Error types: (1) *withstack.withStack (2) *errors.errorString`,
+			`
+(0.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+`,
 		},
 
 		{"newf-empty-arg",
@@ -95,6 +115,15 @@ Error types: (1) *withstack.withStack (2) *errors.errorString`,
 Wraps: (2) 2 safe details enclosed
 Wraps: (3) %!(EXTRA int=123)
 Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errors.errorString`,
+			`
+(0.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(1.1) -- arg 1: <int>
+`,
 		},
 
 		{"wrapf",
@@ -112,6 +141,16 @@ Wraps: (2) 2 safe details enclosed
 Wraps: (3) waa: hello
 Wraps: (4) woo
 Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errutil.withMessage (4) *errors.errorString`,
+			`
+(0.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(1.0) waa: %s
+(1.1) -- arg 1: <string>
+`,
 		},
 
 		{"wrapf-empty",
@@ -127,6 +166,14 @@ woo
   | <tab><path>
 Wraps: (2) woo
 Error types: (1) *withstack.withStack (2) *errors.errorString`,
+			`
+(0.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+`,
 		},
 
 		{"wrapf-empty-arg",
@@ -144,6 +191,15 @@ Wraps: (2) 2 safe details enclosed
 Wraps: (3) %!(EXTRA int=123)
 Wraps: (4) woo
 Error types: (1) *withstack.withStack (2) *safedetails.withSafeDetails (3) *errutil.withMessage (4) *errors.errorString`,
+			`
+(0.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(1.1) -- arg 1: <int>
+`,
 		},
 
 		{"handled assert",
@@ -168,6 +224,16 @@ Wraps: (3) wuu: woo
   | Wraps: (2) woo
   | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
 Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError`,
+			`
+(1.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(2.0) -- details for github.com/cockroachdb/errors/errutil_test/*errutil_test.werrFmt:::
+(2.1) -- details for errors/*errors.errorString:::
+`,
 		},
 
 		{"assert + wrap",
@@ -193,6 +259,18 @@ Wraps: (5) wuu: woo
   | Wraps: (2) woo
   | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
 Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *safedetails.withSafeDetails (4) *errutil.withMessage (5) *barriers.barrierError`,
+			`
+(1.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(2.0) waa: %s
+(2.1) -- arg 1: <string>
+(4.0) -- details for github.com/cockroachdb/errors/errutil_test/*errutil_test.werrFmt:::
+(4.1) -- details for errors/*errors.errorString:::
+`,
 		},
 
 		{"assert + wrap empty",
@@ -216,6 +294,16 @@ Wraps: (3) wuu: woo
   | Wraps: (2) woo
   | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
 Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError`,
+			`
+(1.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(2.0) -- details for github.com/cockroachdb/errors/errutil_test/*errutil_test.werrFmt:::
+(2.1) -- details for errors/*errors.errorString:::
+`,
 		},
 
 		{"assert + wrap empty+arg",
@@ -241,6 +329,17 @@ Wraps: (5) wuu: woo
   | Wraps: (2) woo
   | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
 Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *safedetails.withSafeDetails (4) *errutil.withMessage (5) *barriers.barrierError`,
+			`
+(1.0) github.com/cockroachdb/errors/errutil_test.TestFormat
+      <tab><path>
+      testing.tRunner
+      <tab><path>
+      runtime.goexit
+      <tab><path>
+(2.1) -- arg 1: <int>
+(4.0) -- details for github.com/cockroachdb/errors/errutil_test/*errutil_test.werrFmt:::
+(4.1) -- details for errors/*errors.errorString:::
+`,
 		},
 	}
 
@@ -264,6 +363,26 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *safe
 			spv = fileref.ReplaceAllString(spv, "<path>")
 			spv = strings.ReplaceAll(spv, "\t", "<tab>")
 			tt.CheckStringEqual(spv, refV)
+
+			details := errbase.GetAllSafeDetails(err)
+			var buf strings.Builder
+			for i, d := range details {
+				if len(d.SafeDetails) == 0 || (len(d.SafeDetails) == 1 && d.SafeDetails[0] == "") {
+					continue
+				}
+				for j, sd := range d.SafeDetails {
+					if len(sd) == 0 {
+						continue
+					}
+					sd = fileref.ReplaceAllString(sd, "<path>")
+					sd = strings.ReplaceAll(sd, "\t", "<tab>")
+					sd = strings.ReplaceAll(sd, "\n", "\n      ")
+					sd = strings.TrimSpace(sd)
+					fmt.Fprintf(&buf, "(%d.%d) %s\n", i, j, sd)
+				}
+			}
+			refDetail := strings.TrimPrefix(test.details, "\n")
+			tt.CheckStringEqual(buf.String(), refDetail)
 		})
 	}
 }

--- a/errutil/utilities.go
+++ b/errutil/utilities.go
@@ -62,6 +62,27 @@ func NewWithDepthf(depth int, format string, args ...interface{}) error {
 	return err
 }
 
+// NewV creates an error whose message is given
+// by the provided object.
+//
+// The semantics of NewV(myObj) are nearly equivalent to
+// Newf("%v", myObj). The message produced by myObj
+// is considered safe for reporting if it implements
+// the safe interface.
+func NewV(obj interface{}) error {
+	return NewWithDepthV(1, obj)
+}
+
+// NewWithDepthV is like NewV() except the depth to capture the stack
+// trace is configurable.
+// See the doc of `NewV()` for more details.
+func NewWithDepthV(depth int, obj interface{}) error {
+	err := fmt.Errorf("%v", obj)
+	err = safedetails.WithSafeDetails(err, "", obj)
+	err = withstack.WithStackDepth(err, 1+depth)
+	return err
+}
+
 // Wrap wraps an error with a message prefix.
 // A stack trace is retained.
 //
@@ -100,12 +121,31 @@ func Wrapf(err error, format string, args ...interface{}) error {
 
 // WrapWithDepthf is like Wrapf except the depth to capture the stack
 // trace is configurable.
-// The the doc of `Wrapf()` for more details.
+// See the doc of `Wrapf()` for more details.
 func WrapWithDepthf(depth int, err error, format string, args ...interface{}) error {
 	if format != "" || len(args) > 0 {
 		err = WithMessagef(err, format, args...)
 		err = safedetails.WithSafeDetails(err, format, args...)
 	}
+	err = withstack.WithStackDepth(err, depth+1)
+	return err
+}
+
+// WrapV wraps an error with a message prefix.
+//
+// The semantics of WrapV(err, myObj) are nearly equivalent to
+// Wrapf(err, "%v", myObj). The meessage produced by myObj is
+// considered safe for reporting if it implements the safe interface.
+func WrapV(err error, obj interface{}) error {
+	return WrapWithDepthV(1, err, obj)
+}
+
+// WrapWithDepthV is like WrapV except the depth to capture
+// the stack trace is configurable.
+// See the doc of `WrapV()` for more details.
+func WrapWithDepthV(depth int, err error, obj interface{}) error {
+	err = WithMessagef(err, "%v", obj)
+	err = safedetails.WithSafeDetails(err, "", obj)
 	err = withstack.WithStackDepth(err, depth+1)
 	return err
 }

--- a/errutil_api.go
+++ b/errutil_api.go
@@ -36,6 +36,12 @@ func NewWithDepthf(depth int, format string, args ...interface{}) error {
 	return errutil.NewWithDepthf(depth+1, format, args...)
 }
 
+// NewV forwards a definition.
+func NewV(obj interface{}) error { return errutil.NewWithDepthV(1, obj) }
+
+// NewWithDepthV forwards a definition.
+func NewWithDepthV(depth int, obj interface{}) error { return errutil.NewWithDepthV(depth+1, obj) }
+
 // Errorf forwards a definition.
 func Errorf(format string, args ...interface{}) error {
 	return errutil.NewWithDepthf(1, format, args...)
@@ -88,6 +94,16 @@ func Wrapf(err error, format string, args ...interface{}) error {
 // WrapWithDepthf forwards a definition.
 func WrapWithDepthf(depth int, err error, format string, args ...interface{}) error {
 	return errutil.WrapWithDepthf(depth+1, err, format, args...)
+}
+
+// WrapV forwards a definition.
+func WrapV(err error, obj interface{}) error {
+	return errutil.WrapWithDepthV(1, err, obj)
+}
+
+// WrapWithDepthV forwards a definition.
+func WrapWithDepthV(depth int, err error, obj interface{}) error {
+	return errutil.WrapWithDepthV(depth+1, err, obj)
 }
 
 // AssertionFailedf forwards a definition.


### PR DESCRIPTION
(As discussed in https://github.com/cockroachdb/cockroach/pull/49660#issuecomment-635879096 )

We have found experimentally that it's common to call
`errors.Newf("%v", log.Safe(someData))`.

This patch provides `errors.NewV` as a shorthand for
`errors.Newf("%v", ...)`.

Ditto `WrapV` for symmetry and the "WithDepth" variants.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/35)
<!-- Reviewable:end -->
