### PR TITLE
redact: ensure that SafeMessager leaves are reported

### DIFF
--- a/safedetails/redact.go
+++ b/safedetails/redact.go
@@ -122,6 +122,8 @@ func redactLeafErr(buf *strings.Builder, err error) {
 		typAnd(buf, t, t.Error())
 	case syscall.Errno:
 		typAnd(buf, t, t.Error())
+	case SafeMessager:
+		typAnd(buf, t, t.SafeMessage())
 	default:
 		// No further information about this error, simply report its type.
 		typAnd(buf, err, "")

--- a/safedetails/redact_test.go
+++ b/safedetails/redact_test.go
@@ -44,6 +44,10 @@ func TestRedact(t *testing.T) {
 
 		{mySafer{}, `hello`},
 		{safedetails.Safe(123), `123`},
+		{mySafeError{}, `hello`},
+		{&werrFmt{mySafeError{}, "unseen"},
+			`safedetails_test.mySafeError: hello
+wrapper: <*safedetails_test.werrFmt>`},
 
 		// Redacting errors.
 
@@ -142,3 +146,8 @@ func makeTypeAssertionErr() (result runtime.Error) {
 type mySafer struct{}
 
 func (mySafer) SafeMessage() string { return "hello" }
+
+type mySafeError struct{}
+
+func (mySafeError) SafeMessage() string { return "hello" }
+func (mySafeError) Error() string       { return "helloerr" }


### PR DESCRIPTION
If an object was an `error` and its leaf was also a `SafeMessager`,
the safe message payload was not reported. This fixes that.

Fixes #40.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/42)
<!-- Reviewable:end -->
