### PR TITLE
report,redact: incrementally improve the ergonomics of reports

### DIFF
--- a/contexttags/contexttags_test.go
+++ b/contexttags/contexttags_test.go
@@ -107,8 +107,8 @@ func TestTagRedaction(t *testing.T) {
 
 	// This will be our reference expected value.
 	refStrings := [][]string{
-		[]string{"planet1=<string>", "planet2=universe"},
-		[]string{"foo1=<int>", "x<int>", "bar1", "foo2=123", "y456", "bar2"},
+		[]string{"planet1=string:<redacted>", "planet2=universe"},
+		[]string{"foo1=int:<redacted>", "xint:<redacted>", "bar1", "foo2=123", "y456", "bar2"},
 	}
 
 	// Construct the error object.

--- a/report/report.go
+++ b/report/report.go
@@ -269,7 +269,7 @@ func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]
 			stKey := fmt.Sprintf("%d: details", extraNum)
 			var extraStr bytes.Buffer
 			for _, d := range details[i].SafeDetails {
-				fmt.Fprintln(&extraStr, d)
+				fmt.Fprintln(&extraStr, strings.ReplaceAll(d, "\n", "\n   "))
 			}
 			extras[stKey] = extraStr.String()
 			fmt.Fprintf(&longMsgBuf, " (%d)", extraNum)

--- a/safedetails/safedetails.go
+++ b/safedetails/safedetails.go
@@ -33,8 +33,18 @@ func WithSafeDetails(err error, format string, args ...interface{}) error {
 
 	details := make([]string, 1, 1+len(args))
 	details[0] = format
+	if len(format) > 0 && len(args) > 0 {
+		// Call out that this string was a formatting string.
+		details[0] = fmt.Sprintf("format: %q", details[0])
+	}
 	for i, a := range args {
-		details = append(details, fmt.Sprintf("-- arg %d: %s", i+1, Redact(a)))
+		what := ""
+		if _, ok := a.(error); ok {
+			// Call out that this argument was an error, to facilitate
+			// interpretation of subsequent lines.
+			what = " (error)"
+		}
+		details = append(details, fmt.Sprintf("-- arg %d%s: %s", i+1, what, Redact(a)))
 	}
 	return &withSafeDetails{cause: err, safeDetails: details}
 }

--- a/safedetails/safedetails_test.go
+++ b/safedetails/safedetails_test.go
@@ -90,9 +90,9 @@ Wraps: (2) woo
 Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
 			// Payload
 			`payload 0
-(0) a
+  (0) a
 payload 1
-(empty)
+  (empty)
 `},
 
 		{"safe empty",
@@ -104,9 +104,9 @@ Wraps: (2) woo
 Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
 			// Payload
 			`payload 0
-(empty)
+  (empty)
 payload 1
-(empty)
+  (empty)
 `},
 
 		{"safe nofmt+onearg",
@@ -118,9 +118,9 @@ Wraps: (2) woo
 Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
 			// Payload
 			`payload 0
-(1) -- arg 1: <int>
+  (1) -- arg 1: int:<redacted>
 payload 1
-(empty)
+  (empty)
 `},
 
 		{"safe err",
@@ -137,11 +137,11 @@ Wraps: (2) woo
 Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
 			// Payload
 			`payload 0
-(0) a %v
-(1) -- arg 1: *errors.errorString: file does not exist
-wrapper: *os.PathError: open
+  (0) format: "a %v"
+  (1) -- arg 1 (error): *errors.errorString: file does not exist
+    *os.PathError: open
 payload 1
-(empty)
+  (empty)
 `},
 
 		{"safe",
@@ -153,11 +153,11 @@ Wraps: (2) woo
 Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
 			// Payload
 			`payload 0
-(0) a %s %s
-(1) -- arg 1: <string>
-(2) -- arg 2: c
+  (0) format: "a %s %s"
+  (1) -- arg 1: string:<redacted>
+  (2) -- arg 2: c
 payload 1
-(empty)
+  (empty)
 `},
 
 		{"safe + wrapper",
@@ -172,13 +172,13 @@ Wraps: (3) woo
 Error types: (1) *safedetails.withSafeDetails (2) *safedetails_test.werrFmt (3) *errors.errorString`,
 			// Payload
 			`payload 0
-(0) a %s %s
-(1) -- arg 1: <string>
-(2) -- arg 2: c
+  (0) format: "a %s %s"
+  (1) -- arg 1: string:<redacted>
+  (2) -- arg 2: c
 payload 1
-(empty)
+  (empty)
 payload 2
-(empty)
+  (empty)
 `},
 
 		{"wrapper + safe",
@@ -193,13 +193,13 @@ Wraps: (3) woo
 Error types: (1) *safedetails_test.werrFmt (2) *safedetails.withSafeDetails (3) *errors.errorString`,
 			// Payload
 			`payload 0
-(empty)
+  (empty)
 payload 1
-(0) a %s %s
-(1) -- arg 1: <string>
-(2) -- arg 2: c
+  (0) format: "a %s %s"
+  (1) -- arg 1: string:<redacted>
+  (2) -- arg 2: c
 payload 2
-(empty)
+  (empty)
 `},
 
 		{"safe with wrapped error",
@@ -213,11 +213,11 @@ Wraps: (2) woo
 Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
 			// Payload
 			`payload 0
-(0) a %v
-(1) -- arg 1: <*errors.errorString>
-wrapper: <*safedetails_test.werrFmt>
+  (0) format: "a %v"
+  (1) -- arg 1 (error): *errors.errorString:<redacted>
+    *safedetails_test.werrFmt:<redacted>
 payload 1
-(empty)
+  (empty)
 `},
 
 		{"safe + safe, stacked",
@@ -233,18 +233,20 @@ Wraps: (3) woo
 Error types: (1) *safedetails.withSafeDetails (2) *safedetails.withSafeDetails (3) *errors.errorString`,
 			// Payload
 			`payload 0
-(0) delicious %s
-(1) -- arg 1: coffee
+  (0) format: "delicious %s"
+  (1) -- arg 1: coffee
 payload 1
-(0) hello %s
-(1) -- arg 1: world
+  (0) format: "hello %s"
+  (1) -- arg 1: world
 payload 2
-(empty)
+  (empty)
 `},
 
 		{"safe as arg to safe",
 			safedetails.WithSafeDetails(baseErr, "a %v",
-				safedetails.WithSafeDetails(errors.New("wuu"),
+				/* this error is an argument */
+				safedetails.WithSafeDetails(
+					errors.New("wuu"),
 					"b %v", safedetails.Safe("waa"))),
 			woo,
 			`
@@ -254,14 +256,14 @@ Wraps: (2) woo
 Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString`,
 			// Payload
 			`payload 0
-(0) a %v
-(1) -- arg 1: <*errors.errorString>
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-b %v
--- arg 1: waa
+  (0) format: "a %v"
+  (1) -- arg 1 (error): *errors.errorString:<redacted>
+    *safedetails.withSafeDetails:<redacted>
+    (more details about this error:)
+    format: "b %v"
+    -- arg 1: waa
 payload 1
-(empty)
+  (empty)
 `},
 	}
 
@@ -290,14 +292,14 @@ payload 1
 			for i, d := range details {
 				fmt.Fprintf(&buf, "payload %d\n", i)
 				if len(d.SafeDetails) == 0 || (len(d.SafeDetails) == 1 && d.SafeDetails[0] == "") {
-					fmt.Fprintf(&buf, "(empty)\n")
+					fmt.Fprintf(&buf, "  (empty)\n")
 					continue
 				}
 				for j, sd := range d.SafeDetails {
 					if len(sd) == 0 {
 						continue
 					}
-					fmt.Fprintf(&buf, "(%d) %s\n", j, sd)
+					fmt.Fprintf(&buf, "  (%d) %s\n", j, strings.ReplaceAll(sd, "\n", "\n    "))
 				}
 			}
 			tt.CheckStringEqual(buf.String(), test.details)


### PR DESCRIPTION
Informed by https://github.com/cockroachdb/cockroach/issues/52600

NB: This commit is a transition change until we introduce redaction
markers, which will make a lot of this code obsolete.
Since this is a transition change, it does not aim for perfection.

This change provides the following incremental improvements:

- in the behavior of `Redact()`.

  Previously, a redacted object would be printed as `<type>`.
  With this commit, it is now printed as `type: <redacted>`.
  This makes it clearer that data was redacted out.

  For example: `Redact("hello")`
  Previously: `<string>`
  Now: `string:<redacted>`

- in the behavior of `Redact()`.

  Previously this would print out
  errors using the following format:

  ```
  ...source location...: ...redacted leaf...
  wrapper: ...redacted wrapper...
  wrapper: ...redacted wrapper...
  ```

  Now the `wrapper:` prefix is omitted. Thanks to the change from the
  previous bullet list, this improves this example:

  ```
  replica_raft.go:707: <*storage.Error>
  wrapper: <*errutil.withMessage>
  wrapper: <*withstack.withStack>
  ```

  Into:

  ```
  replica_raft.go:707: *storage.Error:<redacted>
  *errutil.withMessage:<redacted>
  *withstack.withStack:<redacted>
  ````

- in the behavior of `WithSafeDetails()`

  Previously, the arguments passed would be stored as follows:

  ```
  <raw format string>
  -- arg 1: <redacted arg 1>
  -- arg 2: <redacted arg 2>
  ```

  This commit changes this to:

  ```
  format: "quoted format string"
  -- arg 1: <redacted arg 1>
  -- arg 2: <redacted arg 2>
  ```

  Additionally, if the argument type implements `error`, the suffix
  ` (error)` is added between the argument number and the redacted
  error description.

  For example, this improves:

  ```
  %s: %+v
  -- arg 1: while committing batch
  -- arg 2: replica_raft.go:707: *storage.Error:<redacted>
  ```

  Into:

  ```
  format: "%s: %+v"
  -- arg 1: while committing batch
  -- arg 2 (error): replica_raft.go:707: *storage.Error:<redacted>
  ```

  (Note: this format will radically change once we have redaction
  markers. In that case we'll be able to get more data "inline".)

- in the behavior of `BuildSentryReport()`:

  Previously, the safe strings would be inserted as-is in the "details"
  box of a sentry report. This was causing legibility issues, for
  example:

  ```
  -- arg 1: multi-line string for arg
  1, with some more output spanning
  multiple lines
  -- arg 2: another multi-line string
  for arg 2, with more output
  ```

  This patch inserts padding to indent the detail strings:

  ```
  -- arg 1: multi-line string for arg
     1, with some more output spanning
     multiple lines
  -- arg 2: another multi-line string
     for arg 2, with more output
  ```

  A concrete example would be an error argument detail, this improves

  ```
  format: "%s: %+v"
  -- arg 1: while committing batch
  -- arg 2 (error): replica_raft.go:707: *storage.Error:<redacted>
  *errutil.withMessage:<redacted>
  *withstack.withStack:<redacted>
  (more details:)
  <stack trace>
  ```

  Into:

  ```
  format: "%s: %+v"
  -- arg 1: while committing batch
  -- arg 2 (error): replica_raft.go:707: *storage.Error:<redacted>
     *errutil.withMessage: <redacted>
     *withstack.withStack: <redacted>
     (more details:)
     <stack trace>
  ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/43)
<!-- Reviewable:end -->
