### PR TITLE
Fix assignment of sentry report_type tag

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -381,7 +381,7 @@ func ReportError(err error) (eventID string) {
 		"report_type": "error",
 	}
 	for key, value := range tags {
-		event.Tags[key] = tags[value]
+		event.Tags[key] = value
 	}
 
 	res := sentry.CaptureEvent(event)


### PR DESCRIPTION
I found a small bug.  Hopefully this PR is helpful to you guys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/49)
<!-- Reviewable:end -->
