### PR TITLE
markers: delegate to an Is() method if present

### DIFF
--- a/markers_api.go
+++ b/markers_api.go
@@ -19,6 +19,16 @@ import "github.com/cockroachdb/errors/markers"
 // Is determines whether one of the causes of the given error or any
 // of its causes is equivalent to some reference error.
 //
+// As in the Go standard library, an error is considered to match a
+// reference error if it is equal to that target or if it implements a
+// method Is(error) bool such that Is(reference) returns true.
+//
+// Note: the inverse is not true - making an Is(reference) method
+// return false does not imply that errors.Is() also returns
+// false. Errors can be equal because their network equality marker is
+// the same. To force errors to appear different to Is(), use
+// errors.Mark().
+//
 // Note: if any of the error types has been migrated from a previous
 // package location or a different type, ensure that
 // RegisterTypeMigration() was called prior to Is().


### PR DESCRIPTION
Fixes #58 

The Go std `errors` package has this rule about `Is()`:

> An error is considered to match a target if it is equal to that
> target or if it implements a method Is(error) bool such that
> Is(target) returns true.

([source](https://golang.org/pkg/errors/?source=post_page---------------------------#Is))

This patch extends the errors library accordingly.

Caveat: the doc says "if a.Is(b) is true, then errors.Is(a, b) is
true". This is the behavior implemented here. The doc does not say "if
a.Is(b) is false, then errors.Is(a, b) is false".

The CockroachDB errors library uses error identity markers which
enable comparisons across the network. The identity marker includes
only the type and message. Therefore, it is not possible to "make two
errors unequal" by customizing an `Is()` method to return `false`, if
their network identity marker is otherwise equal. To change this
behavior, use the `errors.Mark()` API instead, or implement an
`ErrorTypeKey()` method.

Requested by @romariolopezc in #58 


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/59)
<!-- Reviewable:end -->
