### PR TITLE
Verify "go mod tidy" in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,3 +30,6 @@ jobs:
 
     - name: Test (${{ matrix.go }})
       run: go test ./...
+
+    - name: Tidy (${{ matrix.go }})
+      run: '[[ `go version` < "go version go1.15.10" ]] || go mod tidy'

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ older version of the package.
 
 ## How to use
 
+This library works best with go ≥ 1.15.10. It works with 1.15.9 but breaks `go mod tidy` and `go mod vendor`.
+
 - construct errors with `errors.New()`, etc as usual, but also see the other [error leaf constructors](#Available-error-leaves) below.
 - wrap errors with `errors.Wrap()` as usual, but also see the [other wrappers](#Available-wrapper-constructors) below.
 - test error identity with `errors.Is()` as usual.


### PR DESCRIPTION
Previously, there was no verification that it was possible to run
"go mod tidy" and "go mod vendor" in projects that depend on errors.
This commit adds a CI step to check that these "go mod" commands can
run successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/81)
<!-- Reviewable:end -->
