### PR TITLE
Fully address #82

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,3 +22,7 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+retract (
+	v1.8.5 // Originally tagged for commit hash that was subsequently removed, and replaced by another commit hash
+)


### PR DESCRIPTION
Version v1.8.5 had been originally tagged for commit hash that was subsequently removed, and replaced by another commit hash.
Even though the window of time between the two release events was less than 10 minutes, it was enough to get the go mod proxy confused, resulting in errors about mismatched checksums.

sum.golang.org is intended to guarantee that all Go users see the same code for a given module version. There's no way for it to know whether a change to a release was an intentional fix, a mistake, or an attack. Either way, reproducible builds are fundamental goal of the module ecosystem and users should be able to rely on things not changing invisibly.

If you use proxy.golang.org, it will serve you the same data for the version that sum.golang.org saw.

This adds the [retract directive](https://golang.org/ref/mod#go-mod-file-retract) to the `go.mod` file for cockroachdb/errors so retracted versions will be hidden from the version list printed by `go list -m -versions` unless the `-retracted` flag is used. Retracted versions are excluded when resolving version queries like `@>=v1.2.3` or `@latest`.

This will also prevent consumers of this library that run `go mod verify` and `go mod download -x` from looking at the bad checksum from the older v1.8.5 release after a newer v1.8.7 is published and depended on.

Signed-off-by: Steve Coffman <steve@khanacademy.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/83)
<!-- Reviewable:end -->
