### PR TITLE
add EncodedError.IsSet method

### DIFF
--- a/errbase/decode.go
+++ b/errbase/decode.go
@@ -23,6 +23,8 @@ import (
 )
 
 // DecodeError decodes an error.
+//
+// Can only be called if the EncodedError is set (see IsSet()).
 func DecodeError(ctx context.Context, enc EncodedError) error {
 	if w := enc.GetWrapper(); w != nil {
 		return decodeWrapper(ctx, w)

--- a/errorspb/errors.go
+++ b/errorspb/errors.go
@@ -1,0 +1,21 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package errorspb
+
+// IsSet returns true if the EncodedError contains an error, or false if it is
+// empty.
+func (m *EncodedError) IsSet() bool {
+	return m.Error != nil
+}


### PR DESCRIPTION
This will help clean up awkward checks of the form:
`if e.EncodedError != (errorspb.EncodedError{})`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/84)
<!-- Reviewable:end -->
