### PR TITLE
Ensure context.DeadlineExceeded is preserved through the network.

### DIFF
--- a/errbase/adapters.go
+++ b/errbase/adapters.go
@@ -37,6 +37,11 @@ func decodeErrorString(_ context.Context, msg string, _ []string, _ proto.Messag
 	return goErr.New(msg)
 }
 
+// context.DeadlineExceeded uses a custom type.
+func decodeDeadlineExceeded(_ context.Context, _ string, _ []string, _ proto.Message) error {
+	return context.DeadlineExceeded
+}
+
 // errors.fundamental from github.com/pkg/errors cannot be encoded
 // exactly because it includes a non-serializable stack trace
 // object. In order to work with it, we encode it by dumping
@@ -182,6 +187,8 @@ func encodeOpaqueErrno(
 func init() {
 	baseErr := goErr.New("")
 	RegisterLeafDecoder(GetTypeKey(baseErr), decodeErrorString)
+
+	RegisterLeafDecoder(GetTypeKey(context.DeadlineExceeded), decodeDeadlineExceeded)
 
 	pkgE := pkgErr.New("")
 	RegisterLeafEncoder(GetTypeKey(pkgE), encodePkgFundamental)

--- a/errbase/adapters_test.go
+++ b/errbase/adapters_test.go
@@ -172,6 +172,14 @@ func TestAdaptProtoErrorsWithWrapper(t *testing.T) {
 	tt.CheckDeepEqual(newErr, origErr)
 }
 
+func TestAdaptContextCanceled(t *testing.T) {
+	// context.DeadlineExceeded is preserved exactly.
+
+	tt := testutils.T{T: t}
+	newErr := network(t, context.DeadlineExceeded)
+	tt.CheckEqual(newErr, context.DeadlineExceeded)
+}
+
 func TestAdaptOsErrors(t *testing.T) {
 	// The special os error types are preserved exactly.
 

--- a/fmttests/testdata/format/leaves-via-network
+++ b/fmttests/testdata/format/leaves-via-network
@@ -232,28 +232,12 @@ ctx-deadline oneline twoline
 opaque
 accept %\+v via Formattable.*IRREGULAR: not same as %\+v
 ----
-&errbase.opaqueLeaf{
-    msg:     "context deadline exceeded",
-    details: errorspb.EncodedErrorDetails{
-        OriginalTypeName:  "context/context.deadlineExceededError",
-        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"context/context.deadlineExceededError", Extension:""},
-        ReportablePayload: nil,
-        FullDetails:       (*types.Any)(nil),
-    },
-}
+context.deadlineExceededError{}
 =====
 ===== non-redactable formats
 =====
 == %#v
-&errbase.opaqueLeaf{
-    msg:     "context deadline exceeded",
-    details: errorspb.EncodedErrorDetails{
-        OriginalTypeName:  "context/context.deadlineExceededError",
-        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"context/context.deadlineExceededError", Extension:""},
-        ReportablePayload: nil,
-        FullDetails:       (*types.Any)(nil),
-    },
-}
+context.deadlineExceededError{}
 == Error()
 context deadline exceeded
 == %v = Error(), good
@@ -261,15 +245,15 @@ context deadline exceeded
 == %q = quoted Error(), good
 == %x = hex Error(), good
 == %X = HEX Error(), good
-== %+v
-context deadline exceeded
-(1) context deadline exceeded
-Error types: (1) *errbase.opaqueLeaf
+== %+v = Error(), ok
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
 == %q via Formattable() = quoted %v via Formattable(), good
-== %+v via Formattable() == %+v, good
+== %+v via Formattable() (IRREGULAR: not same as %+v)
+context deadline exceeded
+(1) context deadline exceeded
+Error types: (1) context.deadlineExceededError
 =====
 ===== redactable formats
 =====
@@ -280,10 +264,10 @@ context deadline exceeded
 == printed via redact Printf() %q, refused - good
 == printed via redact Printf() %x, refused - good
 == printed via redact Printf() %X, refused - good
-== printed via redact Printf() %+v, ok - congruent with %+v
+== printed via redact Printf() %+v, ok - congruent with %+v via Formattable()
 context deadline exceeded
 (1) context deadline exceeded
-Error types: (1) *errbase.opaqueLeaf
+Error types: (1) context.deadlineExceededError
 =====
 ===== Sentry reporting
 =====


### PR DESCRIPTION
This is one of the things we discussed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/89)
<!-- Reviewable:end -->
