### PR TITLE
errbase: prevent a call cycle for Formatter/SafeFormatter errors

### DIFF
--- a/fmttests/datadriven_test.go
+++ b/fmttests/datadriven_test.go
@@ -91,6 +91,9 @@ var leafCommands = map[string]commandFn{
 	// errFmt has both Format() and FormatError(),
 	// and demonstrates the common case of "rich" errors.
 	"fmt": func(_ error, args []arg) error { return &errFmt{strfy(args)} },
+	// errSafeFormat has SafeFormatError(), and has Error() and Format()
+	// redirect to that.
+	"safefmt": func(_ error, args []arg) error { return &errSafeFormat{strfy(args)} },
 
 	// errutil.New implements multi-layer errors.
 	"newf": func(_ error, args []arg) error { return errutil.Newf("new-style %s", strfy(args)) },
@@ -176,6 +179,9 @@ var wrapCommands = map[string]commandFn{
 	// werrFmt has both Format() and FormatError(),
 	// and demonstrates the common case of "rich" errors.
 	"fmt": func(err error, args []arg) error { return &werrFmt{err, strfy(args)} },
+	// werrSafeFormat has SafeFormatError(), and has Error() and Format()
+	// redirect to that.
+	"safefmt": func(err error, args []arg) error { return &werrSafeFormat{cause: err, msg: strfy(args)} },
 	// werrEmpty has no message of its own. Its Error() is implemented via its cause.
 	"empty": func(err error, _ []arg) error { return &werrEmpty{err} },
 	// werrDelegate delegates its Error() behavior to FormatError().

--- a/fmttests/format_error_test.go
+++ b/fmttests/format_error_test.go
@@ -317,6 +317,13 @@ Wraps: (3) woo
   | multi-line leaf payload
 Error types: (1) *fmttests.werrDelegateEmpty (2) *errors.withStack (3) *fmttests.errFmt`, ``,
 		},
+
+		{"safeformatter leaf",
+			&errSafeFormat{msg: "world"},
+			`safe world`, `
+safe world
+(1) safe world
+Error types: (1) *fmttests.errSafeFormat`, ``},
 	}
 
 	for _, test := range testCases {
@@ -701,4 +708,28 @@ func (w *werrMigrated) Format(s fmt.State, verb rune) { errbase.FormatError(w, s
 
 func init() {
 	errbase.RegisterTypeMigration("some/previous/path", "prevpkg.prevType", (*werrMigrated)(nil))
+}
+
+type errSafeFormat struct {
+	msg string
+}
+
+func (e *errSafeFormat) Error() string                 { return fmt.Sprint(e) }
+func (e *errSafeFormat) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
+func (e *errSafeFormat) SafeFormatError(p errbase.Printer) (next error) {
+	p.Printf("safe %s", e.msg)
+	return nil
+}
+
+type werrSafeFormat struct {
+	cause error
+	msg   string
+}
+
+func (w *werrSafeFormat) Cause() error                  { return w.cause }
+func (w *werrSafeFormat) Error() string                 { return fmt.Sprint(w) }
+func (w *werrSafeFormat) Format(s fmt.State, verb rune) { errbase.FormatError(w, s, verb) }
+func (w *werrSafeFormat) SafeFormatError(p errbase.Printer) (next error) {
+	p.Printf("safe %s", w.msg)
+	return w.cause
 }

--- a/fmttests/testdata/format/leaves
+++ b/fmttests/testdata/format/leaves
@@ -1492,6 +1492,66 @@ Title: "*errors.fundamental: ×\n×"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 
 run
+safefmt oneline twoline
+
+require (?s)oneline.*twoline
+----
+&fmttests.errSafeFormat{msg:"oneline\ntwoline"}
+=====
+===== non-redactable formats
+=====
+== %#v
+&fmttests.errSafeFormat{msg:"oneline\ntwoline"}
+== Error()
+safe oneline
+twoline
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe oneline
+(1) safe oneline
+  | twoline
+Error types: (1) *fmttests.errSafeFormat
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+safe ‹oneline›
+‹twoline›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+safe ‹oneline›
+(1) safe ‹oneline›
+  | ‹twoline›
+Error types: (1) *fmttests.errSafeFormat
+=====
+===== Sentry reporting
+=====
+== Message payload
+safe ×
+×
+--
+*fmttests.errSafeFormat
+== Extra "error types"
+github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "*fmttests.errSafeFormat"
+Title: "safe ×\n×"
+(NO STACKTRACE)
+
+run
 unimplemented oneline twoline
 
 require (?s)oneline.*twoline

--- a/fmttests/testdata/format/leaves-via-network
+++ b/fmttests/testdata/format/leaves-via-network
@@ -1661,6 +1661,89 @@ Title: "*errors.fundamental: ×\n×"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 
 run
+safefmt oneline twoline
+opaque
+
+require (?s)oneline.*twoline
+----
+&errbase.opaqueLeaf{
+    msg:     "safe oneline\ntwoline",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&errbase.opaqueLeaf{
+    msg:     "safe oneline\ntwoline",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+== Error()
+safe oneline
+twoline
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe oneline
+(1) safe oneline
+  | twoline
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat
+Error types: (1) *errbase.opaqueLeaf
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+‹safe oneline›
+‹twoline›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+‹safe oneline›
+(1) ‹safe oneline›
+  | ‹twoline›
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat
+Error types: (1) *errbase.opaqueLeaf
+=====
+===== Sentry reporting
+=====
+== Message payload
+×
+×
+--
+*fmttests.errSafeFormat
+== Extra "error types"
+github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "*fmttests.errSafeFormat"
+Title: "×\n×"
+(NO STACKTRACE)
+
+run
 unimplemented oneline twoline
 opaque
 

--- a/fmttests/testdata/format/wrap-fmt
+++ b/fmttests/testdata/format/wrap-fmt
@@ -2864,6 +2864,88 @@ Title: "×\n×"
 
 run
 fmt innerone innertwo
+safefmt outerthree outerfour
+
+require (?s)outerthree.*outerfour.*
+----
+&fmttests.werrSafeFormat{
+    cause: &fmttests.errFmt{msg:"innerone\ninnertwo"},
+    msg:   "outerthree\nouterfour",
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&fmttests.werrSafeFormat{
+    cause: &fmttests.errFmt{msg:"innerone\ninnertwo"},
+    msg:   "outerthree\nouterfour",
+}
+== Error()
+safe outerthree
+outerfour: innerone
+innertwo
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe outerthree: innerone
+(1) safe outerthree
+  | outerfour
+Wraps: (2) innerone
+  | innertwo
+  | -- this is innerone
+  | innertwo's
+  | multi-line leaf payload
+Error types: (1) *fmttests.werrSafeFormat (2) *fmttests.errFmt
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+safe ‹outerthree›
+‹outerfour›: ‹innerone›
+‹innertwo›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+safe ‹outerthree›: ‹innerone›
+(1) safe ‹outerthree›
+  | ‹outerfour›
+Wraps: (2) ‹innerone›‹›
+‹  | innertwo›
+‹  | -- this is innerone›
+‹  | innertwo's›
+‹  | multi-line leaf payload›
+Error types: (1) *fmttests.werrSafeFormat (2) *fmttests.errFmt
+=====
+===== Sentry reporting
+=====
+== Message payload
+safe ×
+×: ×
+×
+--
+*fmttests.errFmt
+*fmttests.werrSafeFormat
+== Extra "error types"
+github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
+github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "*fmttests.errFmt"
+Title: "safe ×\n×: ×\n×"
+(NO STACKTRACE)
+
+run
+fmt innerone innertwo
 secondary outerthree outerfour
 
 require (?s)

--- a/fmttests/testdata/format/wrap-fmt-via-network
+++ b/fmttests/testdata/format/wrap-fmt-via-network
@@ -3609,6 +3609,123 @@ Title: "×\n×"
 
 run
 fmt innerone innertwo
+safefmt outerthree outerfour
+opaque
+
+require (?s)outerthree.*outerfour.*innerone.*innertwo
+----
+&errbase.opaqueWrapper{
+    cause: &errbase.opaqueLeaf{
+        msg:     "innerone\ninnertwo",
+        details: errorspb.EncodedErrorDetails{
+            OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.errFmt",
+            ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.errFmt", Extension:""},
+            ReportablePayload: nil,
+            FullDetails:       (*types.Any)(nil),
+        },
+    },
+    prefix:  "safe outerthree\nouterfour",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&errbase.opaqueWrapper{
+    cause: &errbase.opaqueLeaf{
+        msg:     "innerone\ninnertwo",
+        details: errorspb.EncodedErrorDetails{
+            OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.errFmt",
+            ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.errFmt", Extension:""},
+            ReportablePayload: nil,
+            FullDetails:       (*types.Any)(nil),
+        },
+    },
+    prefix:  "safe outerthree\nouterfour",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+== Error()
+safe outerthree
+outerfour: innerone
+innertwo
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe outerthree: innerone
+(1) safe outerthree
+  | outerfour
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) innerone
+  | innertwo
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+‹safe outerthree›
+‹outerfour›: ‹innerone›
+‹innertwo›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+‹safe outerthree›: ‹innerone›
+(1) ‹safe outerthree›
+  | ‹outerfour›
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) ‹innerone›
+  | ‹innertwo›
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+=====
+===== Sentry reporting
+=====
+== Message payload
+×
+×: ×
+×
+--
+*fmttests.errFmt
+*fmttests.werrSafeFormat
+== Extra "error types"
+github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
+github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "*fmttests.errFmt"
+Title: "×\n×: ×\n×"
+(NO STACKTRACE)
+
+run
+fmt innerone innertwo
 secondary outerthree outerfour
 opaque
 

--- a/fmttests/testdata/format/wrap-goerr
+++ b/fmttests/testdata/format/wrap-goerr
@@ -2664,6 +2664,82 @@ Title: "×\n×"
 
 run
 goerr innerone innertwo
+safefmt outerthree outerfour
+
+require (?s)outerthree.*outerfour.*
+----
+&fmttests.werrSafeFormat{
+    cause: &errors.errorString{s:"innerone\ninnertwo"},
+    msg:   "outerthree\nouterfour",
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&fmttests.werrSafeFormat{
+    cause: &errors.errorString{s:"innerone\ninnertwo"},
+    msg:   "outerthree\nouterfour",
+}
+== Error()
+safe outerthree
+outerfour: innerone
+innertwo
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe outerthree: innerone
+(1) safe outerthree
+  | outerfour
+Wraps: (2) innerone
+  | innertwo
+Error types: (1) *fmttests.werrSafeFormat (2) *errors.errorString
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+safe ‹outerthree›
+‹outerfour›: ‹innerone›
+‹innertwo›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+safe ‹outerthree›: ‹innerone›
+(1) safe ‹outerthree›
+  | ‹outerfour›
+Wraps: (2) ‹innerone›‹›
+‹  | innertwo›
+Error types: (1) *fmttests.werrSafeFormat (2) *errors.errorString
+=====
+===== Sentry reporting
+=====
+== Message payload
+safe ×
+×: ×
+×
+--
+*errors.errorString
+*fmttests.werrSafeFormat
+== Extra "error types"
+errors/*errors.errorString (*::)
+github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "*errors.errorString"
+Title: "safe ×\n×: ×\n×"
+(NO STACKTRACE)
+
+run
+goerr innerone innertwo
 secondary outerthree outerfour
 
 require (?s)

--- a/fmttests/testdata/format/wrap-goerr-via-network
+++ b/fmttests/testdata/format/wrap-goerr-via-network
@@ -2920,6 +2920,101 @@ Title: "×\n×"
 
 run
 goerr innerone innertwo
+safefmt outerthree outerfour
+opaque
+
+require (?s)outerthree.*outerfour.*innerone.*innertwo
+----
+&errbase.opaqueWrapper{
+    cause:   &errors.errorString{s:"innerone\ninnertwo"},
+    prefix:  "safe outerthree\nouterfour",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&errbase.opaqueWrapper{
+    cause:   &errors.errorString{s:"innerone\ninnertwo"},
+    prefix:  "safe outerthree\nouterfour",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+== Error()
+safe outerthree
+outerfour: innerone
+innertwo
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe outerthree: innerone
+(1) safe outerthree
+  | outerfour
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) innerone
+  | innertwo
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+‹safe outerthree›
+‹outerfour›: ‹innerone›
+‹innertwo›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+‹safe outerthree›: ‹innerone›
+(1) ‹safe outerthree›
+  | ‹outerfour›
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) ‹innerone›‹›
+‹  | innertwo›
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+=====
+===== Sentry reporting
+=====
+== Message payload
+×
+×: ×
+×
+--
+*errors.errorString
+*fmttests.werrSafeFormat
+== Extra "error types"
+errors/*errors.errorString (*::)
+github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "*errors.errorString"
+Title: "×\n×: ×\n×"
+(NO STACKTRACE)
+
+run
+goerr innerone innertwo
 secondary outerthree outerfour
 opaque
 

--- a/fmttests/testdata/format/wrap-newf
+++ b/fmttests/testdata/format/wrap-newf
@@ -5339,6 +5339,169 @@ Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
 
 run
 newf innerone innertwo
+safefmt outerthree outerfour
+
+require (?s)outerthree.*outerfour.*
+----
+&fmttests.werrSafeFormat{
+    cause: &withstack.withStack{
+        cause: &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
+        stack: &stack{...},
+    },
+    msg: "outerthree\nouterfour",
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&fmttests.werrSafeFormat{
+    cause: &withstack.withStack{
+        cause: &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
+        stack: &stack{...},
+    },
+    msg: "outerthree\nouterfour",
+}
+== Error()
+safe outerthree
+outerfour: new-style innerone
+innertwo
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe outerthree: new-style innerone
+(1) safe outerthree
+  | outerfour
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style innerone
+  | innertwo
+Error types: (1) *fmttests.werrSafeFormat (2) *withstack.withStack (3) *errutil.leafError
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+safe ‹outerthree›
+‹outerfour›: new-style ‹innerone›
+‹innertwo›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+safe ‹outerthree›: new-style ‹innerone›
+(1) safe ‹outerthree›
+  | ‹outerfour›
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ‹innerone›
+  | ‹innertwo›
+Error types: (1) *fmttests.werrSafeFormat (2) *withstack.withStack (3) *errutil.leafError
+=====
+===== Sentry reporting
+=====
+== Message payload
+<path>:<lineno>: safe ×
+×: new-style ×
+×
+--
+*errutil.leafError: new-style × (1)
+<path>:<lineno>: *withstack.withStack (top exception)
+*fmttests.werrSafeFormat
+(check the extra data payloads)
+== Extra "1: details"
+new-style ×
+   ×
+== Extra "error types"
+github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
+github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
+github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "<path>:<lineno> ...funcNN...
+Title: "*errutil.leafError: safe ×\n×: new-style ×\n×\nvia *withstack.withStack"
+<path>:<lineno>:
+   (runtime) goexit()
+<path>:<lineno>:
+   (testing) tRunner()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven.Walk)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) Walk()
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.TestDatadriven)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) RunTest()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runTestInternal()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runDirectiveOrSubTest()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runDirective()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven.runDirective)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
+
+run
+newf innerone innertwo
 secondary outerthree outerfour
 
 require (?s)

--- a/fmttests/testdata/format/wrap-newf-via-network
+++ b/fmttests/testdata/format/wrap-newf-via-network
@@ -6153,6 +6153,206 @@ Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
 
 run
 newf innerone innertwo
+safefmt outerthree outerfour
+opaque
+
+require (?s)outerthree.*outerfour.*innerone.*innertwo
+----
+&errbase.opaqueWrapper{
+    cause: &errbase.opaqueWrapper{
+        cause:   &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
+        prefix:  "",
+        details: errorspb.EncodedErrorDetails{
+            OriginalTypeName:  "github.com/cockroachdb/errors/withstack/*withstack.withStack",
+            ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/withstack/*withstack.withStack", Extension:""},
+            ReportablePayload: {"\ngithub.com/cockroachdb/errors/fmttests.glob...funcNN...\<path>:<lineno>\ngithub.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirective.func1\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirective\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirectiveOrSubTest\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runTestInternal\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.RunTest\n\<path>:<lineno>\ngithub.com/cockroachdb/errors/fmttests.TestDatadriven.func2\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.Walk\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.Walk.func1\n\<path>:<lineno>\ntesting.tRunner\n\<path>:<lineno>\nruntime.goexit\n\<path>:<lineno>"},
+            FullDetails:       (*types.Any)(nil),
+        },
+    },
+    prefix:  "safe outerthree\nouterfour",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&errbase.opaqueWrapper{
+    cause: &errbase.opaqueWrapper{
+        cause:   &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
+        prefix:  "",
+        details: errorspb.EncodedErrorDetails{
+            OriginalTypeName:  "github.com/cockroachdb/errors/withstack/*withstack.withStack",
+            ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/withstack/*withstack.withStack", Extension:""},
+            ReportablePayload: {"\ngithub.com/cockroachdb/errors/fmttests.glob...funcNN...\<path>:<lineno>\ngithub.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirective.func1\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirective\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirectiveOrSubTest\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runTestInternal\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.RunTest\n\<path>:<lineno>\ngithub.com/cockroachdb/errors/fmttests.TestDatadriven.func2\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.Walk\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.Walk.func1\n\<path>:<lineno>\ntesting.tRunner\n\<path>:<lineno>\nruntime.goexit\n\<path>:<lineno>"},
+            FullDetails:       (*types.Any)(nil),
+        },
+    },
+    prefix:  "safe outerthree\nouterfour",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+== Error()
+safe outerthree
+outerfour: new-style innerone
+innertwo
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe outerthree: new-style innerone
+(1) safe outerthree
+  | outerfour
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style innerone
+  | innertwo
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+‹safe outerthree›
+‹outerfour›: new-style ‹innerone›
+‹innertwo›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+‹safe outerthree›: new-style ‹innerone›
+(1) ‹safe outerthree›
+  | ‹outerfour›
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ‹innerone›
+  | ‹innertwo›
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+=====
+===== Sentry reporting
+=====
+== Message payload
+<path>:<lineno>: ×
+×: new-style ×
+×
+--
+*errutil.leafError: new-style × (1)
+<path>:<lineno>: *withstack.withStack (top exception)
+*fmttests.werrSafeFormat
+(check the extra data payloads)
+== Extra "1: details"
+new-style ×
+   ×
+== Extra "error types"
+github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
+github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
+github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "<path>:<lineno> ...funcNN...
+Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+<path>:<lineno>:
+   (runtime) goexit()
+<path>:<lineno>:
+   (testing) tRunner()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven.Walk)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) Walk()
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.TestDatadriven)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) RunTest()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runTestInternal()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runDirectiveOrSubTest()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runDirective()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven.runDirective)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
+
+run
+newf innerone innertwo
 secondary outerthree outerfour
 opaque
 

--- a/fmttests/testdata/format/wrap-nofmt
+++ b/fmttests/testdata/format/wrap-nofmt
@@ -2664,6 +2664,82 @@ Title: "×\n×"
 
 run
 nofmt innerone innertwo
+safefmt outerthree outerfour
+
+require (?s)outerthree.*outerfour.*
+----
+&fmttests.werrSafeFormat{
+    cause: &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
+    msg:   "outerthree\nouterfour",
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&fmttests.werrSafeFormat{
+    cause: &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
+    msg:   "outerthree\nouterfour",
+}
+== Error()
+safe outerthree
+outerfour: innerone
+innertwo
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe outerthree: innerone
+(1) safe outerthree
+  | outerfour
+Wraps: (2) innerone
+  | innertwo
+Error types: (1) *fmttests.werrSafeFormat (2) *fmttests.errNoFmt
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+safe ‹outerthree›
+‹outerfour›: ‹innerone›
+‹innertwo›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+safe ‹outerthree›: ‹innerone›
+(1) safe ‹outerthree›
+  | ‹outerfour›
+Wraps: (2) ‹innerone›‹›
+‹  | innertwo›
+Error types: (1) *fmttests.werrSafeFormat (2) *fmttests.errNoFmt
+=====
+===== Sentry reporting
+=====
+== Message payload
+safe ×
+×: ×
+×
+--
+*fmttests.errNoFmt
+*fmttests.werrSafeFormat
+== Extra "error types"
+github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
+github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "*fmttests.errNoFmt"
+Title: "safe ×\n×: ×\n×"
+(NO STACKTRACE)
+
+run
+nofmt innerone innertwo
 secondary outerthree outerfour
 
 require (?s)

--- a/fmttests/testdata/format/wrap-nofmt-via-network
+++ b/fmttests/testdata/format/wrap-nofmt-via-network
@@ -3609,6 +3609,123 @@ Title: "×\n×"
 
 run
 nofmt innerone innertwo
+safefmt outerthree outerfour
+opaque
+
+require (?s)outerthree.*outerfour.*innerone.*innertwo
+----
+&errbase.opaqueWrapper{
+    cause: &errbase.opaqueLeaf{
+        msg:     "innerone\ninnertwo",
+        details: errorspb.EncodedErrorDetails{
+            OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt",
+            ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt", Extension:""},
+            ReportablePayload: nil,
+            FullDetails:       (*types.Any)(nil),
+        },
+    },
+    prefix:  "safe outerthree\nouterfour",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&errbase.opaqueWrapper{
+    cause: &errbase.opaqueLeaf{
+        msg:     "innerone\ninnertwo",
+        details: errorspb.EncodedErrorDetails{
+            OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt",
+            ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt", Extension:""},
+            ReportablePayload: nil,
+            FullDetails:       (*types.Any)(nil),
+        },
+    },
+    prefix:  "safe outerthree\nouterfour",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+== Error()
+safe outerthree
+outerfour: innerone
+innertwo
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe outerthree: innerone
+(1) safe outerthree
+  | outerfour
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) innerone
+  | innertwo
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+‹safe outerthree›
+‹outerfour›: ‹innerone›
+‹innertwo›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+‹safe outerthree›: ‹innerone›
+(1) ‹safe outerthree›
+  | ‹outerfour›
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) ‹innerone›
+  | ‹innertwo›
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+=====
+===== Sentry reporting
+=====
+== Message payload
+×
+×: ×
+×
+--
+*fmttests.errNoFmt
+*fmttests.werrSafeFormat
+== Extra "error types"
+github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
+github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "*fmttests.errNoFmt"
+Title: "×\n×: ×\n×"
+(NO STACKTRACE)
+
+run
+nofmt innerone innertwo
 secondary outerthree outerfour
 opaque
 

--- a/fmttests/testdata/format/wrap-pkgerr
+++ b/fmttests/testdata/format/wrap-pkgerr
@@ -5046,6 +5046,159 @@ Title: "*errors.fundamental: ×\n×"
 
 run
 pkgerr innerone innertwo
+safefmt outerthree outerfour
+
+require (?s)outerthree.*outerfour.*
+----
+&fmttests.werrSafeFormat{
+    cause: &errors.fundamental{
+        msg:   "innerone\ninnertwo",
+        stack: &stack{...},
+    },
+    msg: "outerthree\nouterfour",
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&fmttests.werrSafeFormat{
+    cause: &errors.fundamental{
+        msg:   "innerone\ninnertwo",
+        stack: &stack{...},
+    },
+    msg: "outerthree\nouterfour",
+}
+== Error()
+safe outerthree
+outerfour: innerone
+innertwo
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe outerthree: innerone
+(1) safe outerthree
+  | outerfour
+Wraps: (2) innerone
+  | innertwo
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *fmttests.werrSafeFormat (2) *errors.fundamental
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+safe ‹outerthree›
+‹outerfour›: ‹innerone›
+‹innertwo›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+safe ‹outerthree›: ‹innerone›
+(1) safe ‹outerthree›
+  | ‹outerfour›
+Wraps: (2) ‹innerone›‹›
+‹  | innertwo›
+‹  | github.com/cockroachdb/errors/fmttests.glob..func9›
+‹  | <tab><path>:<lineno>›
+‹  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1›
+‹  | <tab><path>:<lineno>›
+‹  | github.com/cockroachdb/datadriven.runDirective.func1›
+‹  | <tab><path>:<lineno>›
+‹  | github.com/cockroachdb/datadriven.runDirective›
+‹  | <tab><path>:<lineno>›
+‹  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest›
+‹  | <tab><path>:<lineno>›
+‹  | github.com/cockroachdb/datadriven.runTestInternal›
+‹  | <tab><path>:<lineno>›
+‹  | github.com/cockroachdb/datadriven.RunTest›
+‹  | <tab><path>:<lineno>›
+‹  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2›
+‹  | <tab><path>:<lineno>›
+‹  | github.com/cockroachdb/datadriven.Walk›
+‹  | <tab><path>:<lineno>›
+‹  | github.com/cockroachdb/datadriven.Walk.func1›
+‹  | <tab><path>:<lineno>›
+‹  | testing.tRunner›
+‹  | <tab><path>:<lineno>›
+‹  | runtime.goexit›
+‹  | <tab><path>:<lineno>›
+Error types: (1) *fmttests.werrSafeFormat (2) *errors.fundamental
+=====
+===== Sentry reporting
+=====
+== Message payload
+<path>:<lineno>: safe ×
+×: ×
+×
+--
+<path>:<lineno>: *errors.fundamental (top exception)
+*fmttests.werrSafeFormat
+== Extra "error types"
+github.com/pkg/errors/*errors.fundamental (*::)
+github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "<path>:<lineno> ...funcNN...
+Title: "*errors.fundamental: safe ×\n×: ×\n×"
+<path>:<lineno>:
+   (runtime) goexit()
+<path>:<lineno>:
+   (testing) tRunner()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven.Walk)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) Walk()
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.TestDatadriven)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) RunTest()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runTestInternal()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runDirectiveOrSubTest()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runDirective()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven.runDirective)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
+
+run
+pkgerr innerone innertwo
 secondary outerthree outerfour
 
 require (?s)

--- a/fmttests/testdata/format/wrap-pkgerr-via-network
+++ b/fmttests/testdata/format/wrap-pkgerr-via-network
@@ -5931,6 +5931,198 @@ Title: "*errors.fundamental: ×\n×"
 
 run
 pkgerr innerone innertwo
+safefmt outerthree outerfour
+opaque
+
+require (?s)outerthree.*outerfour.*innerone.*innertwo
+----
+&errbase.opaqueWrapper{
+    cause: &errbase.opaqueLeaf{
+        msg:     "innerone\ninnertwo",
+        details: errorspb.EncodedErrorDetails{
+            OriginalTypeName:  "github.com/pkg/errors/*errors.fundamental",
+            ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/pkg/errors/*errors.fundamental", Extension:""},
+            ReportablePayload: {"\ngithub.com/cockroachdb/errors/fmttests.glob...funcNN...\<path>:<lineno>\ngithub.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirective.func1\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirective\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirectiveOrSubTest\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runTestInternal\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.RunTest\n\<path>:<lineno>\ngithub.com/cockroachdb/errors/fmttests.TestDatadriven.func2\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.Walk\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.Walk.func1\n\<path>:<lineno>\ntesting.tRunner\n\<path>:<lineno>\nruntime.goexit\n\<path>:<lineno>"},
+            FullDetails:       (*types.Any)(nil),
+        },
+    },
+    prefix:  "safe outerthree\nouterfour",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+=====
+===== non-redactable formats
+=====
+== %#v
+&errbase.opaqueWrapper{
+    cause: &errbase.opaqueLeaf{
+        msg:     "innerone\ninnertwo",
+        details: errorspb.EncodedErrorDetails{
+            OriginalTypeName:  "github.com/pkg/errors/*errors.fundamental",
+            ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/pkg/errors/*errors.fundamental", Extension:""},
+            ReportablePayload: {"\ngithub.com/cockroachdb/errors/fmttests.glob...funcNN...\<path>:<lineno>\ngithub.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirective.func1\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirective\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runDirectiveOrSubTest\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.runTestInternal\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.RunTest\n\<path>:<lineno>\ngithub.com/cockroachdb/errors/fmttests.TestDatadriven.func2\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.Walk\n\<path>:<lineno>\ngithub.com/cockroachdb/datadriven.Walk.func1\n\<path>:<lineno>\ntesting.tRunner\n\<path>:<lineno>\nruntime.goexit\n\<path>:<lineno>"},
+            FullDetails:       (*types.Any)(nil),
+        },
+    },
+    prefix:  "safe outerthree\nouterfour",
+    details: errorspb.EncodedErrorDetails{
+        OriginalTypeName:  "github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat",
+        ErrorTypeMark:     errorspb.ErrorTypeMark{FamilyName:"github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat", Extension:""},
+        ReportablePayload: nil,
+        FullDetails:       (*types.Any)(nil),
+    },
+}
+== Error()
+safe outerthree
+outerfour: innerone
+innertwo
+== %v = Error(), good
+== %s = Error(), good
+== %q = quoted Error(), good
+== %x = hex Error(), good
+== %X = HEX Error(), good
+== %+v
+safe outerthree: innerone
+(1) safe outerthree
+  | outerfour
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) innerone
+  | innertwo
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+== %#v via Formattable() = %#v, good
+== %v via Formattable() = Error(), good
+== %s via Formattable() = %v via Formattable(), good
+== %q via Formattable() = quoted %v via Formattable(), good
+== %+v via Formattable() == %+v, good
+=====
+===== redactable formats
+=====
+== printed via redact Print(), ok - congruent with %v
+‹safe outerthree›
+‹outerfour›: ‹innerone›
+‹innertwo›
+== printed via redact Printf() %v = Print(), good
+== printed via redact Printf() %s = Print(), good
+== printed via redact Printf() %q, refused - good
+== printed via redact Printf() %x, refused - good
+== printed via redact Printf() %X, refused - good
+== printed via redact Printf() %+v, ok - congruent with %+v
+‹safe outerthree›: ‹innerone›
+(1) ‹safe outerthree›
+  | ‹outerfour›
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) ‹innerone›
+  | ‹innertwo›
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+=====
+===== Sentry reporting
+=====
+== Message payload
+<path>:<lineno>: ×
+×: ×
+×
+--
+<path>:<lineno>: *errors.fundamental (top exception)
+*fmttests.werrSafeFormat
+== Extra "error types"
+github.com/pkg/errors/*errors.fundamental (*::)
+github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
+== Exception 1 (Module: "error domain: <none>")
+Type: "<path>:<lineno> ...funcNN...
+Title: "*errors.fundamental: ×\n×: ×\n×"
+<path>:<lineno>:
+   (runtime) goexit()
+<path>:<lineno>:
+   (testing) tRunner()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven.Walk)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) Walk()
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.TestDatadriven)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) RunTest()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runTestInternal()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runDirectiveOrSubTest()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven) runDirective()
+<path>:<lineno>:
+   (github.com/cockroachdb/datadriven.runDirective)...funcNN...
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
+<path>:<lineno>:
+   (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
+
+run
+pkgerr innerone innertwo
 secondary outerthree outerfour
 opaque
 


### PR DESCRIPTION
Fixes #88.

We've found a need somewhere to implement an `Error()` method on a
leaf by delegating the behavior to the `Formatter` or `SafeFormatter`
interfaces. In that case, the `errors.IsAny` call inside the
special handler causes a call cycle.

This commit breaks the cycle by handling the special cases after
the interfaces.

A possible regression would be that one of the stdlib errors
starts implementing `fmt.Formatter`, whereby we'd lose the special
handling (which, as of this writing, extracts safe strings).
At the time of this writing, none of the stdlib errors of interest
implement `fmt.Formatter`, so we're punting dealing with that
when/if it arises in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/90)
<!-- Reviewable:end -->
