### PR TITLE
Improve the structure of sentry reports

### DIFF
--- a/barriers/barriers.go
+++ b/barriers/barriers.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/errors/errbase"
+	"github.com/cockroachdb/redact"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -88,6 +89,7 @@ func (e *barrierError) SafeDetails() []string {
 		sd := errbase.GetSafeDetails(err)
 		details = sd.Fill(details)
 	}
+	details = append(details, redact.Sprintf("masked error: %+v", e.maskedErr).Redact().StripMarkers())
 	return details
 }
 

--- a/barriers/barriers.go
+++ b/barriers/barriers.go
@@ -37,7 +37,7 @@ func Handled(err error) error {
 	if err == nil {
 		return nil
 	}
-	return HandledWithMessage(err, err.Error())
+	return HandledWithSafeMessage(err, redact.Sprint(err))
 }
 
 // HandledWithMessage is like Handled except the message is overridden.
@@ -47,7 +47,14 @@ func HandledWithMessage(err error, msg string) error {
 	if err == nil {
 		return nil
 	}
-	return &barrierError{maskedErr: err, msg: msg}
+	return HandledWithSafeMessage(err, redact.Sprint(msg))
+}
+
+// HandledWithSafeMessage is like Handled except the message is overridden.
+// This can be used e.g. to hide message details or to prevent
+// downstream code to make assertions on the message's contents.
+func HandledWithSafeMessage(err error, msg redact.RedactableString) error {
+	return &barrierErr{maskedErr: err, smsg: msg}
 }
 
 // HandledWithMessagef is like HandledWithMessagef except the message
@@ -56,34 +63,34 @@ func HandledWithMessagef(err error, format string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
-	return &barrierError{maskedErr: err, msg: fmt.Sprintf(format, args...)}
+	return &barrierErr{maskedErr: err, smsg: redact.Sprintf(format, args...)}
 }
 
-// barrierError is a leaf error type. It encapsulates a chain of
+// barrierErr is a leaf error type. It encapsulates a chain of
 // original causes, but these causes are hidden so that they inhibit
 // matching via Is() and the Cause()/Unwrap() recursions.
-type barrierError struct {
+type barrierErr struct {
 	// Message for the barrier itself.
 	// In the common case, the message from the masked error
 	// is used as-is (see Handled() above) however it is
 	// useful to cache it here since the masked error may
 	// have a long chain of wrappers and its Error() call
 	// may be expensive.
-	msg string
+	smsg redact.RedactableString
 	// Masked error chain.
 	maskedErr error
 }
 
-var _ error = (*barrierError)(nil)
-var _ errbase.SafeDetailer = (*barrierError)(nil)
-var _ errbase.SafeFormatter = (*barrierError)(nil)
-var _ fmt.Formatter = (*barrierError)(nil)
+var _ error = (*barrierErr)(nil)
+var _ errbase.SafeDetailer = (*barrierErr)(nil)
+var _ errbase.SafeFormatter = (*barrierErr)(nil)
+var _ fmt.Formatter = (*barrierErr)(nil)
 
-// barrierError is an error.
-func (e *barrierError) Error() string { return e.msg }
+// barrierErr is an error.
+func (e *barrierErr) Error() string { return e.smsg.StripMarkers() }
 
 // SafeDetails reports the PII-free details from the masked error.
-func (e *barrierError) SafeDetails() []string {
+func (e *barrierErr) SafeDetails() []string {
 	var details []string
 	for err := e.maskedErr; err != nil; err = errbase.UnwrapOnce(err) {
 		sd := errbase.GetSafeDetails(err)
@@ -94,10 +101,10 @@ func (e *barrierError) SafeDetails() []string {
 }
 
 // Printing a barrier reveals the details.
-func (e *barrierError) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
+func (e *barrierErr) Format(s fmt.State, verb rune) { errbase.FormatError(e, s, verb) }
 
-func (e *barrierError) SafeFormatError(p errbase.Printer) (next error) {
-	p.Print(e.msg)
+func (e *barrierErr) SafeFormatError(p errbase.Printer) (next error) {
+	p.Print(e.smsg)
 	if p.Detail() {
 		p.Printf("-- cause hidden behind barrier\n%+v", e.maskedErr)
 	}
@@ -108,19 +115,37 @@ func (e *barrierError) SafeFormatError(p errbase.Printer) (next error) {
 func encodeBarrier(
 	ctx context.Context, err error,
 ) (msg string, details []string, payload proto.Message) {
-	e := err.(*barrierError)
+	e := err.(*barrierErr)
 	enc := errbase.EncodeError(ctx, e.maskedErr)
-	return e.msg, e.SafeDetails(), &enc
+	return string(e.smsg), e.SafeDetails(), &enc
 }
 
 // A barrier error is decoded exactly.
 func decodeBarrier(ctx context.Context, msg string, _ []string, payload proto.Message) error {
 	enc := payload.(*errbase.EncodedError)
-	return &barrierError{msg: msg, maskedErr: errbase.DecodeError(ctx, *enc)}
+	return &barrierErr{smsg: redact.RedactableString(msg), maskedErr: errbase.DecodeError(ctx, *enc)}
 }
 
+// Previous versions of barrier errors.
+func decodeBarrierPrev(ctx context.Context, msg string, _ []string, payload proto.Message) error {
+	enc := payload.(*errbase.EncodedError)
+	return &barrierErr{smsg: redact.Sprint(msg), maskedErr: errbase.DecodeError(ctx, *enc)}
+}
+
+// barrierError is the "old" type name of barrierErr. We use a new
+// name now to ensure a different decode function is used when
+// importing barriers from the previous structure, where the
+// message is not redactable.
+type barrierError struct {
+	msg       string
+	maskedErr error
+}
+
+func (b *barrierError) Error() string { return "" }
+
 func init() {
-	tn := errbase.GetTypeKey((*barrierError)(nil))
+	errbase.RegisterLeafDecoder(errbase.GetTypeKey((*barrierError)(nil)), decodeBarrierPrev)
+	tn := errbase.GetTypeKey((*barrierErr)(nil))
 	errbase.RegisterLeafDecoder(tn, decodeBarrier)
 	errbase.RegisterLeafEncoder(tn, encodeBarrier)
 }

--- a/barriers/barriers_test.go
+++ b/barriers/barriers_test.go
@@ -118,7 +118,7 @@ woo
   | woo
   | (1) woo
   | Error types: (1) *errors.errorString
-Error types: (1) *barriers.barrierError`},
+Error types: (1) *barriers.barrierErr`},
 
 		{"handled + handled", barriers.Handled(barriers.Handled(goErr.New("woo"))), woo, `
 woo
@@ -130,8 +130,8 @@ woo
   |   | woo
   |   | (1) woo
   |   | Error types: (1) *errors.errorString
-  | Error types: (1) *barriers.barrierError
-Error types: (1) *barriers.barrierError`},
+  | Error types: (1) *barriers.barrierErr
+Error types: (1) *barriers.barrierErr`},
 
 		{"handledmsg", barriers.HandledWithMessage(goErr.New("woo"), "waa"), "waa", `
 waa
@@ -140,7 +140,7 @@ waa
   | woo
   | (1) woo
   | Error types: (1) *errors.errorString
-Error types: (1) *barriers.barrierError`},
+Error types: (1) *barriers.barrierErr`},
 
 		{"handledmsg + handledmsg", barriers.HandledWithMessage(
 			barriers.HandledWithMessage(
@@ -154,8 +154,8 @@ wuu
   |   | woo
   |   | (1) woo
   |   | Error types: (1) *errors.errorString
-  | Error types: (1) *barriers.barrierError
-Error types: (1) *barriers.barrierError`},
+  | Error types: (1) *barriers.barrierErr
+Error types: (1) *barriers.barrierErr`},
 
 		{"handled + wrapper",
 			barriers.Handled(
@@ -172,7 +172,7 @@ waa: woo
   |   | multi-line wrapper payload
   | Wraps: (2) woo
   | Error types: (1) *barriers_test.werrFmt (2) *errors.errorString
-Error types: (1) *barriers.barrierError`},
+Error types: (1) *barriers.barrierErr`},
 	}
 
 	for _, test := range testCases {

--- a/errutil/message_test.go
+++ b/errutil/message_test.go
@@ -124,7 +124,7 @@ Wraps: (4) wuu: woo
   |   | multi-line payload
   | Wraps: (2) woo
   | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError`,
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr`,
 		},
 
 		{"assert + wrap empty",
@@ -148,7 +148,7 @@ Wraps: (3) wuu: woo
   |   | multi-line payload
   | Wraps: (2) woo
   | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError`,
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr`,
 		},
 
 		{"assert + wrap empty+arg",
@@ -173,7 +173,7 @@ Wraps: (4) wuu: woo
   |   | multi-line payload
   | Wraps: (2) woo
   | Error types: (1) *errutil_test.werrFmt (2) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError`,
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr`,
 		},
 	}
 

--- a/fmttests/testdata/format/leaves
+++ b/fmttests/testdata/format/leaves
@@ -112,22 +112,47 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *erru
 =====
 == Message payload
 <path>:<lineno>: assertmsg ×
-×
---
-*errutil.leafError: assertmsg × (1)
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg ×
+  | ×
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: assertmsg ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-assertmsg ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: assertmsg ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: assertmsg ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -198,7 +223,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 context canceled
---
+(1) context canceled
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -252,7 +279,9 @@ Error types: (1) context.deadlineExceededError
 =====
 == Message payload
 context deadline exceeded
---
+(1) context deadline exceeded
+Error types: (1) context.deadlineExceededError
+-- report composition:
 context.deadlineExceededError
 == Extra "error types"
 context/context.deadlineExceededError (*::)
@@ -317,14 +346,19 @@ Error types: (1) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+×
+×
+×
+Error types: (1) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -386,14 +420,16 @@ Error types: (1) *fmttests.errFmto
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Error types: (1) *fmttests.errFmto
+-- report composition:
 *fmttests.errFmto
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmto"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -455,14 +491,16 @@ Error types: (1) *fmttests.errFmtoDelegate
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Error types: (1) *fmttests.errFmtoDelegate
+-- report composition:
 *fmttests.errFmtoDelegate
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmtoDelegate"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -515,14 +553,16 @@ Error types: (1) *fmttests.errFmtp
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Error types: (1) *fmttests.errFmtp
+-- report composition:
 *fmttests.errFmtp
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmtp"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -578,14 +618,16 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -696,20 +738,44 @@ Error types: (1) *withstack.withStack (2) *errutil.leafError
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) new-style ×
+  | ×
+Error types: (1) *withstack.withStack (2) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -739,7 +805,6 @@ run
 newf-attached oneline twoline
 
 require (?s)oneline.*twoline
-----
 ----
 &withstack.withStack{
     cause: &secondary.withSecondaryError{
@@ -916,51 +981,76 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×: payload
---
-*errutil.leafError: new-style × (1)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | payload
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | ×: payload
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×: payload
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×: payload\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -985,8 +1075,6 @@ Title: "*errutil.leafError: new-style ×\n×: payload\nvia *withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 nofmt oneline twoline
@@ -1038,14 +1126,16 @@ Error types: (1) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Error types: (1) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1093,7 +1183,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 file already closed
---
+(1) file already closed
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -1147,7 +1239,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 file already exists
---
+(1) file already exists
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -1201,7 +1295,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 invalid argument
---
+(1) invalid argument
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -1255,7 +1351,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 file does not exist
---
+(1) file does not exist
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -1309,7 +1407,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 permission denied
---
+(1) permission denied
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -1458,14 +1558,41 @@ Error types: (1) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) ××
 ×
---
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1541,14 +1668,16 @@ Error types: (1) *fmttests.errSafeFormat
 =====
 == Message payload
 safe ×
-×
---
+(1) safe ×
+  | ×
+Error types: (1) *fmttests.errSafeFormat
+-- report composition:
 *fmttests.errSafeFormat
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errSafeFormat"
-Title: "safe ×\n×"
+Title: "safe ×"
 (NO STACKTRACE)
 
 run
@@ -1613,16 +1742,17 @@ Error types: (1) *issuelink.unimplementedError
 =====
 == Message payload
 ×
-×
---
-*issuelink.unimplementedError: https://mysite (1)
-(check the extra data payloads)
-== Extra "1: details"
-https://mysite
-issuedetails
+(1) ×
+  | ×
+  | unimplemented
+  | issue: https://mysite
+  | detail: issuedetails
+Error types: (1) *issuelink.unimplementedError
+-- report composition:
+*issuelink.unimplementedError: https://mysite
 == Extra "error types"
 github.com/cockroachdb/errors/issuelink/*issuelink.unimplementedError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*issuelink.unimplementedError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)

--- a/fmttests/testdata/format/leaves-via-network
+++ b/fmttests/testdata/format/leaves-via-network
@@ -131,22 +131,50 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *er
 =====
 == Message payload
 <path>:<lineno>: assertmsg ×
-×
---
-*errutil.leafError: assertmsg × (1)
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg ×
+  | ×
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: assertmsg ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-assertmsg ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: assertmsg ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: assertmsg ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -218,7 +246,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 context canceled
---
+(1) context canceled
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -273,7 +303,9 @@ Error types: (1) context.deadlineExceededError
 =====
 == Message payload
 context deadline exceeded
---
+(1) context deadline exceeded
+Error types: (1) context.deadlineExceededError
+-- report composition:
 context.deadlineExceededError
 == Extra "error types"
 context/context.deadlineExceededError (*::)
@@ -355,14 +387,19 @@ Error types: (1) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -441,14 +478,19 @@ Error types: (1) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmto
+Error types: (1) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmto
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmto"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -527,14 +569,19 @@ Error types: (1) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmtoDelegate
+Error types: (1) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmtoDelegate
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmtoDelegate"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -610,14 +657,19 @@ Error types: (1) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmtp
+Error types: (1) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmtp
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmtp"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -674,14 +726,16 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -811,20 +865,47 @@ Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -855,7 +936,6 @@ newf-attached oneline twoline
 opaque
 
 require (?s)oneline.*twoline
-----
 ----
 &errbase.opaqueWrapper{
     cause: &secondary.withSecondaryError{
@@ -1068,51 +1148,82 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×: payload
---
-*errutil.leafError: new-style × (1)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | payload
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | ×: payload
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×: payload
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×: payload\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1137,8 +1248,6 @@ Title: "*errutil.leafError: new-style ×\n×: payload\nvia *withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 nofmt oneline twoline
@@ -1213,14 +1322,19 @@ Error types: (1) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1269,7 +1383,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 file already closed
---
+(1) file already closed
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -1324,7 +1440,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 file already exists
---
+(1) file already exists
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -1379,7 +1497,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 invalid argument
---
+(1) invalid argument
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -1434,7 +1554,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 file does not exist
---
+(1) file does not exist
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -1489,7 +1611,9 @@ Error types: (1) *errors.errorString
 =====
 == Message payload
 permission denied
---
+(1) permission denied
+Error types: (1) *errors.errorString
+-- report composition:
 *errors.errorString
 == Extra "error types"
 errors/*errors.errorString (*::)
@@ -1627,14 +1751,45 @@ Error types: (1) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1733,14 +1888,19 @@ Error types: (1) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat
+Error types: (1) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errSafeFormat
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errSafeFormat"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1806,16 +1966,17 @@ Error types: (1) *issuelink.unimplementedError
 =====
 == Message payload
 ×
-×
---
-*issuelink.unimplementedError: https://mysite (1)
-(check the extra data payloads)
-== Extra "1: details"
-https://mysite
-issuedetails
+(1) ×
+  | ×
+  | unimplemented
+  | issue: https://mysite
+  | detail: issuedetails
+Error types: (1) *issuelink.unimplementedError
+-- report composition:
+*issuelink.unimplementedError: https://mysite
 == Extra "error types"
 github.com/cockroachdb/errors/issuelink/*issuelink.unimplementedError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*issuelink.unimplementedError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)

--- a/fmttests/testdata/format/opaque
+++ b/fmttests/testdata/format/opaque
@@ -69,14 +69,19 @@ Error types: (1) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -168,10 +173,19 @@ Error types: (1) *fmttests.werrFmt (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+×
+×
+×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *fmttests.werrFmt (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrFmt
 == Extra "error types"
@@ -179,7 +193,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -283,10 +297,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrNoFmt
 == Extra "error types"
@@ -294,7 +317,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -417,11 +440,24 @@ Error types: (1) *fmttests.werrFmt (2) *errbase.opaqueWrapper (3) *errbase.opaqu
 ===== Sentry reporting
 =====
 == Message payload
+×: ×: ×
+(1) ××
 ×
-×: ×
-×: ×
 ×
---
+×
+×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (3) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *fmttests.werrFmt (2) *errbase.opaqueWrapper (3) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrNoFmt
 *fmttests.werrFmt
@@ -431,7 +467,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×: ×\n×"
+Title: "×: ×: ×"
 (NO STACKTRACE)
 
 run
@@ -566,11 +602,24 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errbase.
 ===== Sentry reporting
 =====
 == Message payload
-×
-×: ×
-×: ×
-×
---
+×: ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (3) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrNoFmt
 *fmttests.werrNoFmt
@@ -580,7 +629,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×: ×\n×"
+Title: "×: ×: ×"
 (NO STACKTRACE)
 
 run
@@ -734,12 +783,29 @@ Error types: (1) *fmttests.werrFmt (2) *errbase.opaqueWrapper (3) *errbase.opaqu
 ===== Sentry reporting
 =====
 == Message payload
+×: ×: ×: ×
+(1) ××
 ×
-×: ×
-×: ×
-×: ×
 ×
---
+×
+×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (3) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (4) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *fmttests.werrFmt (2) *errbase.opaqueWrapper (3) *errbase.opaqueWrapper (4) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrNoFmt
 *fmttests.werrNoFmt
@@ -751,5 +817,5 @@ github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×: ×\n×: ×\n×"
+Title: "×: ×: ×: ×"
 (NO STACKTRACE)

--- a/fmttests/testdata/format/wrap-fmt
+++ b/fmttests/testdata/format/wrap-fmt
@@ -6,8 +6,8 @@ require (?s)
 ----
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &fmttests.errFmt{msg:"innerone\ninnertwo"},
         },
         stack: &stack{...},
@@ -19,8 +19,8 @@ require (?s)
 == %#v
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &fmttests.errFmt{msg:"innerone\ninnertwo"},
         },
         stack: &stack{...},
@@ -73,7 +73,7 @@ Wraps: (3) innerone
   |   | innertwo's
   |   | multi-line leaf payload
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -129,7 +129,7 @@ Wraps: (3) ‹innerone›
   | ‹  | innertwo's›
   | ‹  | multi-line leaf payload›
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -172,18 +172,18 @@ Wraps: (3) ×
   | ×
   | ×
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -218,8 +218,8 @@ require (?s)outerthree.*outerfour.*
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &fmttests.errFmt{msg:"innerone\ninnertwo"},
             },
             prefix: "assertmsg: ‹outerthree›\n‹outerfour›",
@@ -234,8 +234,8 @@ require (?s)outerthree.*outerfour.*
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &fmttests.errFmt{msg:"innerone\ninnertwo"},
             },
             prefix: "assertmsg: ‹outerthree›\n‹outerfour›",
@@ -293,7 +293,7 @@ Wraps: (4) innerone
   |   | innertwo's
   |   | multi-line leaf payload
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -352,7 +352,7 @@ Wraps: (4) ‹innerone›
   | ‹  | innertwo's›
   | ‹  | multi-line leaf payload›
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -397,20 +397,20 @@ Wraps: (4) ×
   | ×
   | ×
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -442,16 +442,16 @@ barrier outerthree outerfour
 
 require (?s)
 ----
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &fmttests.errFmt{msg:"innerone\ninnertwo"},
 }
 =====
 ===== non-redactable formats
 =====
 == %#v
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &fmttests.errFmt{msg:"innerone\ninnertwo"},
 }
 == Error()
@@ -474,7 +474,7 @@ innerone
   |   | innertwo's
   |   | multi-line leaf payload
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -503,7 +503,7 @@ Error types: (1) *barriers.barrierError
   | ‹  | innertwo's›
   | ‹  | multi-line leaf payload›
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -519,13 +519,13 @@ Error types: (1) *barriers.barrierError
   | ×
   | ×
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 
@@ -1609,8 +1609,8 @@ handled-domain outerthree outerfour
 require (?s)
 ----
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &fmttests.errFmt{msg:"innerone\ninnertwo"},
     },
     domain: "error domain: pkg <path>",
@@ -1620,8 +1620,8 @@ require (?s)
 =====
 == %#v
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &fmttests.errFmt{msg:"innerone\ninnertwo"},
     },
     domain: "error domain: pkg <path>",
@@ -1647,7 +1647,7 @@ Wraps: (2) innerone
   |   | innertwo's
   |   | multi-line leaf payload
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -1677,7 +1677,7 @@ Wraps: (2) ‹innerone›
   | ‹  | innertwo's›
   | ‹  | multi-line leaf payload›
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -1694,15 +1694,15 @@ Wraps: (2) ×
   | ×
   | ×
   | Error types: (1) *fmttests.errFmt
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *domains.withDomain: error domain: pkg <path>
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 

--- a/fmttests/testdata/format/wrap-fmt
+++ b/fmttests/testdata/format/wrap-fmt
@@ -135,27 +135,55 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barr
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
-*barriers.barrierError: masked error: × (1)
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | ×
+  | ×
+  | ×
+  | Error types: (1) *fmttests.errFmt
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   ×
-   ×
-   ×
-   Error types: (1) *fmttests.errFmt
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -329,26 +357,52 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *erru
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×
-×: ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*errutil.withPrefix: assertmsg: × (2)
+<path>:<lineno>: assertmsg: ×: ×
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg: ×
+  | ×
+Wraps: (4) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | ×
+  | ×
+  | ×
+  | Error types: (1) *fmttests.errFmt
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   ×
-   ×
-   ×
-   Error types: (1) *fmttests.errFmt
-== Extra "2: details"
-assertmsg: ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -356,7 +410,7 @@ github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -455,23 +509,24 @@ Error types: (1) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   ×
-   ×
-   ×
-   Error types: (1) *fmttests.errFmt
+(1) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | ×
+  | ×
+  | ×
+  | Error types: (1) *fmttests.errFmt
+Error types: (1) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -546,10 +601,18 @@ Error types: (1) *fmttests.werrDelegate (2) *fmttests.errFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+×
+×
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *fmttests.werrDelegate (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrDelegate
 == Extra "error types"
@@ -557,7 +620,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -623,8 +686,14 @@ Error types: (1) *fmttests.werrDelegateEmpty (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1)
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *fmttests.werrDelegateEmpty (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrDelegateEmpty
 == Extra "error types"
@@ -632,7 +701,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -698,8 +767,14 @@ Error types: (1) *fmttests.werrDelegateNoPrefix (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *fmttests.werrDelegateNoPrefix (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrDelegateNoPrefix
 == Extra "error types"
@@ -707,7 +782,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -777,8 +852,15 @@ Error types: (1) *hintdetail.withDetail (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *hintdetail.withDetail (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *hintdetail.withDetail
 == Extra "error types"
@@ -786,7 +868,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withDetail (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -854,19 +936,22 @@ Error types: (1) *domains.withDomain (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) mydomain
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *domains.withDomain (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
-*domains.withDomain: mydomain (1)
-(check the extra data payloads)
-== Extra "1: details"
-mydomain
+*domains.withDomain: mydomain
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::mydomain)
 == Exception 1 (Module: "mydomain")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -936,8 +1021,15 @@ Error types: (1) *fmttests.werrWithElidedCause (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *fmttests.werrWithElidedCause (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrWithElidedCause
 == Extra "error types"
@@ -945,7 +1037,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrWithElidedCause (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1011,8 +1103,14 @@ Error types: (1) *fmttests.werrEmpty (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1)
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *fmttests.werrEmpty (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrEmpty
 == Extra "error types"
@@ -1020,7 +1118,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1097,10 +1195,19 @@ Error types: (1) *fmttests.werrFmt (2) *fmttests.errFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+×
+×
+×
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *fmttests.werrFmt (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrFmt
 == Extra "error types"
@@ -1108,7 +1215,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1193,10 +1300,16 @@ Error types: (1) *fmttests.werrFmto (2) *fmttests.errFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *fmttests.werrFmto (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrFmto
 == Extra "error types"
@@ -1204,7 +1317,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1289,10 +1402,16 @@ Error types: (1) *fmttests.werrFmtoDelegate (2) *fmttests.errFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *fmttests.werrFmtoDelegate (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrFmtoDelegate
 == Extra "error types"
@@ -1300,7 +1419,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1371,10 +1490,16 @@ Error types: (1) *fmttests.werrFmtp (2) *fmttests.errFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *fmttests.werrFmtp (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrFmtp
 == Extra "error types"
@@ -1382,7 +1507,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1457,10 +1582,16 @@ Error types: (1) *fmt.wrapError (2) *fmttests.errFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *fmt.wrapError (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmt.wrapError
 == Extra "error types"
@@ -1468,7 +1599,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 fmt/*fmt.wrapError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1552,27 +1683,27 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*domains.withDomain: error domain: pkg <path> (2)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   ×
-   ×
-   ×
-   Error types: (1) *fmttests.errFmt
-== Extra "2: details"
-error domain: pkg <path>
+(1) error domain: pkg <path>
+Wraps: (2) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | ×
+  | ×
+  | ×
+  | Error types: (1) *fmttests.errFmt
+Error types: (1) *domains.withDomain (2) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*domains.withDomain: error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1642,8 +1773,15 @@ Error types: (1) *hintdetail.withHint (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *hintdetail.withHint (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *hintdetail.withHint
 == Extra "error types"
@@ -1651,7 +1789,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withHint (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1723,21 +1861,24 @@ Error types: (1) *issuelink.withIssueLink (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) issue: https://mysite
+  | detail: outerthree
+  | outerfour
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *issuelink.withIssueLink (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
-*issuelink.withIssueLink: https://mysite (1)
-(check the extra data payloads)
-== Extra "1: details"
-https://mysite
-outerthree
-   outerfour
+*issuelink.withIssueLink: https://mysite
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/issuelink/*issuelink.withIssueLink (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1803,8 +1944,14 @@ Error types: (1) *fmttests.werrMigrated (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1)
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *fmttests.werrMigrated (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrMigrated
 == Extra "error types"
@@ -1812,7 +1959,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated (some/previous/path/prevpkg.prevType::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1883,22 +2030,24 @@ Error types: (1) *errutil.withPrefix (2) *fmttests.errFmt
 ===== Sentry reporting
 =====
 == Message payload
-outerthree
-outerfour: ×
+outerthree: ×
+(1) outerthree
+  | outerfour
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *errutil.withPrefix (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
-*errutil.withPrefix: outerthree (1)
-(check the extra data payloads)
-== Extra "1: details"
-outerthree
-   outerfour
+*errutil.withPrefix: outerthree
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "outerthree\nouterfour: ×\n×"
+Title: "outerthree: ×"
 (NO STACKTRACE)
 
 run
@@ -2052,18 +2201,54 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 =====
 == Message payload
 <path>:<lineno>: new-style (×
-×) :: ×
-× ::
---
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | ×
+  | (1) ××
+  | ×
+  | ×
+  | ×
+  | ×
+  | Error types: (1) *fmttests.errFmt
+Wraps: (3) new-style (×
+  | ×) :: ×
+  | × ::
+Wraps: (4) ××
+×
+×
+×
+×
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.withNewMessage (4) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
-*errutil.withNewMessage: new-style (× (1)
+*errutil.withNewMessage: new-style (×
 *secondary.withSecondaryError
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style (×
-   ×) :: ×
-   × ::
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withNewMessage (*::)
@@ -2071,7 +2256,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errFmt: new-style (×\n×) :: ×\n× ::\nvia *withstack.withStack"
+Title: "*fmttests.errFmt: new-style (×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2169,10 +2354,16 @@ Error types: (1) *fmttests.werrNoFmt (2) *fmttests.errFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *fmttests.werrNoFmt (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrNoFmt
 == Extra "error types"
@@ -2180,7 +2371,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2256,8 +2447,14 @@ Error types: (1) *os.LinkError (2) *fmttests.errFmt
 =====
 == Message payload
 link × ×: ×
+(1) link × ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *os.LinkError (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *os.LinkError
 == Extra "error types"
@@ -2265,7 +2462,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 os/*os.LinkError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "link × ×: ×\n×"
+Title: "link × ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2343,8 +2540,14 @@ Error types: (1) *net.OpError (2) *fmttests.errFmt
 =====
 == Message payload
 send tcp ×: ×
+(1) send tcp ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *net.OpError (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *net.OpError
 == Extra "error types"
@@ -2352,7 +2555,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 net/*net.OpError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "send tcp ×: ×\n×"
+Title: "send tcp ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2426,8 +2629,14 @@ Error types: (1) *fs.PathError (2) *fmttests.errFmt
 =====
 == Message payload
 link ×: ×
+(1) link ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *fs.PathError (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fs.PathError
 == Extra "error types"
@@ -2435,7 +2644,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 io/fs/*fs.PathError (os/*os.PathError::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "link ×: ×\n×"
+Title: "link ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2507,8 +2716,14 @@ Error types: (1) *os.SyscallError (2) *fmttests.errFmt
 =====
 == Message payload
 open: ×
+(1) open
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *os.SyscallError (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *os.SyscallError
 == Extra "error types"
@@ -2516,7 +2731,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 os/*os.SyscallError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "open: ×\n×"
+Title: "open: ×"
 (NO STACKTRACE)
 
 run
@@ -2609,10 +2824,16 @@ Error types: (1) *errors.withMessage (2) *fmttests.errFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+Error types: (1) *errors.withMessage (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *errors.withMessage
 == Extra "error types"
@@ -2620,7 +2841,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/pkg/errors/*errors.withMessage (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2778,8 +2999,39 @@ Error types: (1) *errors.withStack (2) *fmttests.errFmt
 =====
 == Message payload
 <path>:<lineno>: ×
+(1)
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *errors.withStack (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 <path>:<lineno>: *errors.withStack (top exception)
 == Extra "error types"
@@ -2787,7 +3039,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/pkg/errors/*errors.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errFmt: ×\n×\nvia *errors.withStack"
+Title: "*fmttests.errFmt: ×\nvia *errors.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2880,20 +3132,23 @@ Error types: (1) *safedetails.withSafeDetails (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) safe ×
+  | ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *safedetails.withSafeDetails (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
-*safedetails.withSafeDetails: safe × (1)
-(check the extra data payloads)
-== Extra "1: details"
-safe ×
-   ×
+*safedetails.withSafeDetails: safe ×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/safedetails/*safedetails.withSafeDetails (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2964,10 +3219,16 @@ Error types: (1) *fmttests.werrSafeFormat (2) *fmttests.errFmt
 ===== Sentry reporting
 =====
 == Message payload
-safe ×
-×: ×
+safe ×: ×
+(1) safe ×
+  | ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *fmttests.werrSafeFormat (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrSafeFormat
 == Extra "error types"
@@ -2975,7 +3236,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "safe ×\n×: ×\n×"
+Title: "safe ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2983,7 +3244,6 @@ fmt innerone innertwo
 secondary outerthree outerfour
 
 require (?s)
-----
 ----
 &secondary.withSecondaryError{
     cause:          &fmttests.errFmt{msg:"innerone\ninnertwo"},
@@ -3110,50 +3370,53 @@ Error types: (1) *secondary.withSecondaryError (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) secondary error attachment
+  | outerthree
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) outerthree
+  |   | outerfour
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *secondary.withSecondaryError (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  outerthree
-   outerfour
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 fmt innerone innertwo
@@ -3270,8 +3533,39 @@ Error types: (1) *withstack.withStack (2) *fmttests.errFmt
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *withstack.withStack (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
 <path>:<lineno>: *withstack.withStack (top exception)
 == Extra "error types"
@@ -3279,7 +3573,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errFmt: ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errFmt: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3426,20 +3720,22 @@ Error types: (1) *contexttags.withContext (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) tags: [k×,safe=456]
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *contexttags.withContext (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
-*contexttags.withContext: k× (1)
-(check the extra data payloads)
-== Extra "1: details"
-k×
-safe=456
+*contexttags.withContext: k×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/contexttags/*contexttags.withContext (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3509,21 +3805,23 @@ Error types: (1) *telemetrykeys.withTelemetry (2) *fmttests.errFmt
 =====
 == Message payload
 ×
+(1) keys: [somekey outerthree
+  | outerfour]
+Wraps: (2) ××
 ×
---
+×
+×
+×
+Error types: (1) *telemetrykeys.withTelemetry (2) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
-*telemetrykeys.withTelemetry: somekey (1)
-(check the extra data payloads)
-== Extra "1: details"
-somekey
-outerthree
-   outerfour
+*telemetrykeys.withTelemetry: somekey
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3652,24 +3950,52 @@ Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *fmttests.errF
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-stylew ×
-×: ×
+<path>:<lineno>: new-stylew ×: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) new-stylew ×
+  | ×
+Wraps: (3) ××
 ×
---
+×
+×
+×
+Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
-*errutil.withPrefix: new-stylew × (1)
+*errutil.withPrefix: new-stylew ×
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-stylew ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errFmt: new-stylew ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errFmt: new-stylew ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3700,7 +4026,6 @@ fmt innerone innertwo
 wrapf-attached outerthree outerfour
 
 require (?s)outerthree.*outerfour.*
-----
 ----
 &withstack.withStack{
     cause: &secondary.withSecondaryError{
@@ -3894,47 +4219,76 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-style ×
-× (payload): ×
+<path>:<lineno>: new-style ×: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | payload
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | × (payload)
+Wraps: (4) ××
 ×
---
+×
+×
+×
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.withPrefix (4) *fmttests.errFmt
+-- report composition:
 *fmttests.errFmt
-*errutil.withPrefix: new-style × (1)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
+*errutil.withPrefix: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   × (payload)
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -3942,7 +4296,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errFmt: new-style ×\n× (payload): ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errFmt: new-style ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3967,5 +4321,3 @@ Title: "*fmttests.errFmt: new-style ×\n× (payload): ×\n×\nvia *withstack.wit
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----

--- a/fmttests/testdata/format/wrap-fmt
+++ b/fmttests/testdata/format/wrap-fmt
@@ -137,9 +137,18 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barr
 <path>:<lineno>: ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   ×
+   ×
+   ×
+   Error types: (1) *fmttests.errFmt
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -324,12 +333,20 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *erru
 ×: ×
 ×
 --
-*barriers.barrierError
-*errutil.withPrefix: assertmsg: × (1)
+*barriers.barrierError: masked error: × (1)
+*errutil.withPrefix: assertmsg: × (2)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   ×
+   ×
+   ×
+   Error types: (1) *fmttests.errFmt
+== Extra "2: details"
 assertmsg: ×
    ×
 == Extra "error types"
@@ -440,7 +457,16 @@ Error types: (1) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   ×
+   ×
+   ×
+   Error types: (1) *fmttests.errFmt
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
@@ -1528,10 +1554,18 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
-*domains.withDomain: error domain: pkg <path> (1)
+*barriers.barrierError: masked error: × (1)
+*domains.withDomain: error domain: pkg <path> (2)
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   ×
+   ×
+   ×
+   Error types: (1) *fmttests.errFmt
+== Extra "2: details"
 error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)

--- a/fmttests/testdata/format/wrap-fmt-via-network
+++ b/fmttests/testdata/format/wrap-fmt-via-network
@@ -7,8 +7,8 @@ require (?s)innerone.*innertwo
 ----
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errbase.opaqueLeaf{
                 msg:     "innerone\ninnertwo",
                 details: errorspb.EncodedErrorDetails{
@@ -34,8 +34,8 @@ require (?s)innerone.*innertwo
 == %#v
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errbase.opaqueLeaf{
                 msg:     "innerone\ninnertwo",
                 details: errorspb.EncodedErrorDetails{
@@ -105,7 +105,7 @@ Wraps: (3) innerone
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -164,7 +164,7 @@ Wraps: (3) ‹innerone›
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -210,18 +210,18 @@ Wraps: (3) ×
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -257,8 +257,8 @@ require (?s)outerthree.*outerfour.*innerone.*innertwo
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errbase.opaqueLeaf{
                     msg:     "innerone\ninnertwo",
                     details: errorspb.EncodedErrorDetails{
@@ -287,8 +287,8 @@ require (?s)outerthree.*outerfour.*innerone.*innertwo
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errbase.opaqueLeaf{
                     msg:     "innerone\ninnertwo",
                     details: errorspb.EncodedErrorDetails{
@@ -363,7 +363,7 @@ Wraps: (4) innerone
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -425,7 +425,7 @@ Wraps: (4) ‹innerone›
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -473,20 +473,20 @@ Wraps: (4) ×
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -519,8 +519,8 @@ opaque
 
 require (?s)innerone.*innertwo
 ----
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errbase.opaqueLeaf{
         msg:     "innerone\ninnertwo",
         details: errorspb.EncodedErrorDetails{
@@ -535,8 +535,8 @@ require (?s)innerone.*innertwo
 ===== non-redactable formats
 =====
 == %#v
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errbase.opaqueLeaf{
         msg:     "innerone\ninnertwo",
         details: errorspb.EncodedErrorDetails{
@@ -567,7 +567,7 @@ innerone
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -596,7 +596,7 @@ Error types: (1) *barriers.barrierError
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -612,13 +612,13 @@ Error types: (1) *barriers.barrierError
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 
@@ -2055,8 +2055,8 @@ opaque
 require (?s)innerone.*innertwo
 ----
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errbase.opaqueLeaf{
             msg:     "innerone\ninnertwo",
             details: errorspb.EncodedErrorDetails{
@@ -2074,8 +2074,8 @@ require (?s)innerone.*innertwo
 =====
 == %#v
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errbase.opaqueLeaf{
             msg:     "innerone\ninnertwo",
             details: errorspb.EncodedErrorDetails{
@@ -2109,7 +2109,7 @@ Wraps: (2) innerone
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -2139,7 +2139,7 @@ Wraps: (2) ‹innerone›
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -2156,15 +2156,15 @@ Wraps: (2) ×
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *domains.withDomain: error domain: pkg <path>
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 

--- a/fmttests/testdata/format/wrap-fmt-via-network
+++ b/fmttests/testdata/format/wrap-fmt-via-network
@@ -172,9 +172,18 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *ba
 <path>:<lineno>: ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+   Error types: (1) *errbase.opaqueLeaf
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -394,12 +403,20 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *er
 ×: ×
 ×
 --
-*barriers.barrierError
-*errutil.withPrefix: assertmsg: × (1)
+*barriers.barrierError: masked error: × (1)
+*errutil.withPrefix: assertmsg: × (2)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+   Error types: (1) *errbase.opaqueLeaf
+== Extra "2: details"
 assertmsg: ×
    ×
 == Extra "error types"
@@ -527,7 +544,16 @@ Error types: (1) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+   Error types: (1) *errbase.opaqueLeaf
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
@@ -1965,10 +1991,18 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
-*domains.withDomain: error domain: pkg <path> (1)
+*barriers.barrierError: masked error: × (1)
+*domains.withDomain: error domain: pkg <path> (2)
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+   Error types: (1) *errbase.opaqueLeaf
+== Extra "2: details"
 error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)

--- a/fmttests/testdata/format/wrap-fmt-via-network
+++ b/fmttests/testdata/format/wrap-fmt-via-network
@@ -170,27 +170,58 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *ba
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
-*barriers.barrierError: masked error: × (1)
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
-   Error types: (1) *errbase.opaqueLeaf
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -399,26 +430,55 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *er
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×
-×: ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*errutil.withPrefix: assertmsg: × (2)
+<path>:<lineno>: assertmsg: ×: ×
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg: ×
+  | ×
+Wraps: (4) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
-   Error types: (1) *errbase.opaqueLeaf
-== Extra "2: details"
-assertmsg: ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -426,7 +486,7 @@ github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -542,23 +602,24 @@ Error types: (1) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
-   Error types: (1) *errbase.opaqueLeaf
+(1) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -664,10 +725,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrDelegate
 == Extra "error types"
@@ -675,7 +745,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -776,8 +846,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrDelegateEmpty
 == Extra "error types"
@@ -785,7 +863,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -886,8 +964,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrDelegateNoPrefix
 == Extra "error types"
@@ -895,7 +981,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -982,8 +1068,15 @@ Error types: (1) *hintdetail.withDetail (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *hintdetail.withDetail (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *hintdetail.withDetail
 == Extra "error types"
@@ -991,7 +1084,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withDetail (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1076,19 +1169,22 @@ Error types: (1) *domains.withDomain (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) mydomain
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *domains.withDomain (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
-*domains.withDomain: mydomain (1)
-(check the extra data payloads)
-== Extra "1: details"
-mydomain
+*domains.withDomain: mydomain
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::mydomain)
 == Exception 1 (Module: "mydomain")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1175,8 +1271,15 @@ Error types: (1) *fmttests.werrWithElidedCause (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *fmttests.werrWithElidedCause (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrWithElidedCause
 == Extra "error types"
@@ -1184,7 +1287,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrWithElidedCause (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1285,8 +1388,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrEmpty
 == Extra "error types"
@@ -1294,7 +1405,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1400,10 +1511,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrFmt
 == Extra "error types"
@@ -1411,7 +1531,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1520,10 +1640,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrFmto
 == Extra "error types"
@@ -1531,7 +1660,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1640,10 +1769,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrFmtoDelegate
 == Extra "error types"
@@ -1651,7 +1789,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1757,10 +1895,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrFmtp
 == Extra "error types"
@@ -1768,7 +1915,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1877,10 +2024,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: fmt/*fmt.wrapError
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmt.wrapError
 == Extra "error types"
@@ -1888,7 +2044,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 fmt/*fmt.wrapError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1989,27 +2145,27 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*domains.withDomain: error domain: pkg <path> (2)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
-   Error types: (1) *errbase.opaqueLeaf
-== Extra "2: details"
-error domain: pkg <path>
+(1) error domain: pkg <path>
+Wraps: (2) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *domains.withDomain (2) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*domains.withDomain: error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2096,8 +2252,15 @@ Error types: (1) *hintdetail.withHint (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *hintdetail.withHint (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *hintdetail.withHint
 == Extra "error types"
@@ -2105,7 +2268,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withHint (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2194,21 +2357,24 @@ Error types: (1) *issuelink.withIssueLink (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) issue: https://mysite
+  | detail: outerthree
+  | outerfour
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *issuelink.withIssueLink (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
-*issuelink.withIssueLink: https://mysite (1)
-(check the extra data payloads)
-== Extra "1: details"
-https://mysite
-outerthree
-   outerfour
+*issuelink.withIssueLink: https://mysite
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/issuelink/*issuelink.withIssueLink (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2309,8 +2475,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrMigrated
 == Extra "error types"
@@ -2318,7 +2492,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated (some/previous/path/prevpkg.prevType::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2406,22 +2580,24 @@ Error types: (1) *errutil.withPrefix (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-outerthree
-outerfour: ×
-×
---
+outerthree: ×
+(1) outerthree
+  | outerfour
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errutil.withPrefix (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
-*errutil.withPrefix: outerthree (1)
-(check the extra data payloads)
-== Extra "1: details"
-outerthree
-   outerfour
+*errutil.withPrefix: outerthree
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "outerthree\nouterfour: ×\n×"
+Title: "outerthree: ×"
 (NO STACKTRACE)
 
 run
@@ -2626,18 +2802,57 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 =====
 == Message payload
 <path>:<lineno>: new-style (×
-×) :: ×
-× ::
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+  | Error types: (1) *errbase.opaqueLeaf
+Wraps: (3) new-style (×
+  | ×) :: ×
+  | × ::
+Wraps: (4) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.withNewMessage (4) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
-*errutil.withNewMessage: new-style (× (1)
+*errutil.withNewMessage: new-style (×
 *secondary.withSecondaryError
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style (×
-   ×) :: ×
-   × ::
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withNewMessage (*::)
@@ -2645,7 +2860,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errFmt: new-style (×\n×) :: ×\n× ::\nvia *withstack.withStack"
+Title: "*fmttests.errFmt: new-style (×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2777,10 +2992,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrNoFmt
 == Extra "error types"
@@ -2788,7 +3012,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2889,8 +3113,14 @@ Error types: (1) *os.LinkError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 link × ×: ×
-×
---
+(1) link × ×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *os.LinkError (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *os.LinkError
 == Extra "error types"
@@ -2898,7 +3128,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 os/*os.LinkError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "link × ×: ×\n×"
+Title: "link × ×: ×"
 (NO STACKTRACE)
 
 run
@@ -3004,8 +3234,17 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×: ×
-×
---
+(1) ×
+  |
+  | (opaque error wrapper)
+  | type name: net/*net.OpError
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *net.OpError
 == Extra "error types"
@@ -3013,7 +3252,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 net/*net.OpError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -3112,8 +3351,14 @@ Error types: (1) *fs.PathError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 link ×: ×
-×
---
+(1) link ×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *fs.PathError (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fs.PathError
 == Extra "error types"
@@ -3121,7 +3366,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 io/fs/*fs.PathError (os/*os.PathError::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "link ×: ×\n×"
+Title: "link ×: ×"
 (NO STACKTRACE)
 
 run
@@ -3218,8 +3463,14 @@ Error types: (1) *os.SyscallError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 open: ×
-×
---
+(1) open
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *os.SyscallError (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *os.SyscallError
 == Extra "error types"
@@ -3227,7 +3478,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 os/*os.SyscallError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "open: ×\n×"
+Title: "open: ×"
 (NO STACKTRACE)
 
 run
@@ -3337,10 +3588,16 @@ Error types: (1) *errors.withMessage (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errors.withMessage (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *errors.withMessage
 == Extra "error types"
@@ -3348,7 +3605,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/pkg/errors/*errors.withMessage (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -3506,8 +3763,42 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/pkg/errors/*errors.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 <path>:<lineno>: *errors.withStack (top exception)
 == Extra "error types"
@@ -3515,7 +3806,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/pkg/errors/*errors.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errFmt: ×\n×\nvia *errors.withStack"
+Title: "*fmttests.errFmt: ×\nvia *errors.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3625,20 +3916,23 @@ Error types: (1) *safedetails.withSafeDetails (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) safe ×
+  | ×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *safedetails.withSafeDetails (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
-*safedetails.withSafeDetails: safe × (1)
-(check the extra data payloads)
-== Extra "1: details"
-safe ×
-   ×
+*safedetails.withSafeDetails: safe ×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/safedetails/*safedetails.withSafeDetails (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3744,10 +4038,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 *fmttests.werrSafeFormat
 == Extra "error types"
@@ -3755,7 +4058,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -3764,7 +4067,6 @@ secondary outerthree outerfour
 opaque
 
 require (?s)innerone.*innertwo
-----
 ----
 &secondary.withSecondaryError{
     cause: &errbase.opaqueLeaf{
@@ -3925,50 +4227,56 @@ Error types: (1) *secondary.withSecondaryError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) secondary error attachment
+  | outerthree
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) outerthree
+  |   | outerfour
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *secondary.withSecondaryError (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  outerthree
-   outerfour
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 fmt innerone innertwo
@@ -4120,8 +4428,42 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
 <path>:<lineno>: *withstack.withStack (top exception)
 == Extra "error types"
@@ -4129,7 +4471,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errFmt: ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errFmt: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4285,20 +4627,22 @@ Error types: (1) *contexttags.withContext (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) tags: [k×,safe=×]
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *contexttags.withContext (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
-*contexttags.withContext: k× (1)
-(check the extra data payloads)
-== Extra "1: details"
-k×
-safe=456
+*contexttags.withContext: k×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/contexttags/*contexttags.withContext (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -4385,21 +4729,23 @@ Error types: (1) *telemetrykeys.withTelemetry (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) keys: [somekey outerthree
+  | outerfour]
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *telemetrykeys.withTelemetry (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
-*telemetrykeys.withTelemetry: somekey (1)
-(check the extra data payloads)
-== Extra "1: details"
-somekey
-outerthree
-   outerfour
+*telemetrykeys.withTelemetry: somekey
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -4563,24 +4909,55 @@ Error types: (1) *errbase.opaqueWrapper (2) *errutil.withPrefix (3) *errbase.opa
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-stylew ×
-×: ×
-×
---
+<path>:<lineno>: new-stylew ×: ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) new-stylew ×
+  | ×
+Wraps: (3) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errutil.withPrefix (3) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
-*errutil.withPrefix: new-stylew × (1)
+*errutil.withPrefix: new-stylew ×
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-stylew ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errFmt: new-stylew ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errFmt: new-stylew ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4612,7 +4989,6 @@ wrapf-attached outerthree outerfour
 opaque
 
 require (?s)outerthree.*outerfour.*innerone.*innertwo
-----
 ----
 &errbase.opaqueWrapper{
     cause: &secondary.withSecondaryError{
@@ -4858,47 +5234,82 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-style ×
-× (payload): ×
-×
---
+<path>:<lineno>: new-style ×: ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | payload
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | × (payload)
+Wraps: (4) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errFmt
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.withPrefix (4) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errFmt
-*errutil.withPrefix: new-style × (1)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
+*errutil.withPrefix: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   × (payload)
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -4906,7 +5317,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errFmt: new-style ×\n× (payload): ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errFmt: new-style ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4931,5 +5342,3 @@ Title: "*fmttests.errFmt: new-style ×\n× (payload): ×\n×\nvia *withstack.wit
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----

--- a/fmttests/testdata/format/wrap-goerr
+++ b/fmttests/testdata/format/wrap-goerr
@@ -6,8 +6,8 @@ require (?s)
 ----
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
         },
         stack: &stack{...},
@@ -19,8 +19,8 @@ require (?s)
 == %#v
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
         },
         stack: &stack{...},
@@ -70,7 +70,7 @@ Wraps: (3) innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -123,7 +123,7 @@ Wraps: (3) ‹innerone›
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -163,18 +163,18 @@ Wraps: (3) ×
   | (1) ××
   | ×
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -209,8 +209,8 @@ require (?s)outerthree.*outerfour.*
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
             },
             prefix: "assertmsg: ‹outerthree›\n‹outerfour›",
@@ -225,8 +225,8 @@ require (?s)outerthree.*outerfour.*
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
             },
             prefix: "assertmsg: ‹outerthree›\n‹outerfour›",
@@ -281,7 +281,7 @@ Wraps: (4) innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -337,7 +337,7 @@ Wraps: (4) ‹innerone›
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -379,20 +379,20 @@ Wraps: (4) ×
   | (1) ××
   | ×
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -424,16 +424,16 @@ barrier outerthree outerfour
 
 require (?s)
 ----
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
 }
 =====
 ===== non-redactable formats
 =====
 == %#v
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
 }
 == Error()
@@ -453,7 +453,7 @@ innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *errors.errorString
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -479,7 +479,7 @@ Error types: (1) *barriers.barrierError
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *errors.errorString
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -492,13 +492,13 @@ Error types: (1) *barriers.barrierError
   | (1) ××
   | ×
   | Error types: (1) *errors.errorString
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 
@@ -1464,8 +1464,8 @@ handled-domain outerthree outerfour
 require (?s)
 ----
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
     },
     domain: "error domain: pkg <path>",
@@ -1475,8 +1475,8 @@ require (?s)
 =====
 == %#v
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
     },
     domain: "error domain: pkg <path>",
@@ -1499,7 +1499,7 @@ Wraps: (2) innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *errors.errorString
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -1526,7 +1526,7 @@ Wraps: (2) ‹innerone›
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *errors.errorString
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -1540,15 +1540,15 @@ Wraps: (2) ×
   | (1) ××
   | ×
   | Error types: (1) *errors.errorString
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *domains.withDomain: error domain: pkg <path>
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 

--- a/fmttests/testdata/format/wrap-goerr
+++ b/fmttests/testdata/format/wrap-goerr
@@ -131,9 +131,15 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barr
 <path>:<lineno>: ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *errors.errorString
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -312,12 +318,17 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *erru
 ×: ×
 ×
 --
-*barriers.barrierError
-*errutil.withPrefix: assertmsg: × (1)
+*barriers.barrierError: masked error: × (1)
+*errutil.withPrefix: assertmsg: × (2)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *errors.errorString
+== Extra "2: details"
 assertmsg: ×
    ×
 == Extra "error types"
@@ -422,7 +433,13 @@ Error types: (1) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *errors.errorString
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
@@ -1422,10 +1439,15 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
-*domains.withDomain: error domain: pkg <path> (1)
+*barriers.barrierError: masked error: × (1)
+*domains.withDomain: error domain: pkg <path> (2)
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *errors.errorString
+== Extra "2: details"
 error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)

--- a/fmttests/testdata/format/wrap-goerr
+++ b/fmttests/testdata/format/wrap-goerr
@@ -129,24 +129,52 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barr
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
-*barriers.barrierError: masked error: × (1)
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *errors.errorString
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *errors.errorString
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -314,23 +342,49 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *erru
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×
-×: ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*errutil.withPrefix: assertmsg: × (2)
+<path>:<lineno>: assertmsg: ×: ×
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg: ×
+  | ×
+Wraps: (4) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *errors.errorString
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *errors.errorString
-== Extra "2: details"
-assertmsg: ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -338,7 +392,7 @@ github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -431,20 +485,21 @@ Error types: (1) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *errors.errorString
+(1) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *errors.errorString
+Error types: (1) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -513,10 +568,15 @@ Error types: (1) *fmttests.werrDelegate (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+×
+×
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrDelegate (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrDelegate
 == Extra "error types"
@@ -524,7 +584,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -584,8 +644,11 @@ Error types: (1) *fmttests.werrDelegateEmpty (2) *errors.errorString
 =====
 == Message payload
 ×
+(1)
+Wraps: (2) ××
 ×
---
+Error types: (1) *fmttests.werrDelegateEmpty (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrDelegateEmpty
 == Extra "error types"
@@ -593,7 +656,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -653,8 +716,11 @@ Error types: (1) *fmttests.werrDelegateNoPrefix (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *fmttests.werrDelegateNoPrefix (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrDelegateNoPrefix
 == Extra "error types"
@@ -662,7 +728,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -726,8 +792,12 @@ Error types: (1) *hintdetail.withDetail (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *hintdetail.withDetail (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *hintdetail.withDetail
 == Extra "error types"
@@ -735,7 +805,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withDetail (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -797,19 +867,19 @@ Error types: (1) *domains.withDomain (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) mydomain
+Wraps: (2) ××
 ×
---
+Error types: (1) *domains.withDomain (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*domains.withDomain: mydomain (1)
-(check the extra data payloads)
-== Extra "1: details"
-mydomain
+*domains.withDomain: mydomain
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::mydomain)
 == Exception 1 (Module: "mydomain")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -873,8 +943,12 @@ Error types: (1) *fmttests.werrWithElidedCause (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrWithElidedCause (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrWithElidedCause
 == Extra "error types"
@@ -882,7 +956,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrWithElidedCause (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -942,8 +1016,11 @@ Error types: (1) *fmttests.werrEmpty (2) *errors.errorString
 =====
 == Message payload
 ×
+(1)
+Wraps: (2) ××
 ×
---
+Error types: (1) *fmttests.werrEmpty (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrEmpty
 == Extra "error types"
@@ -951,7 +1028,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1022,10 +1099,16 @@ Error types: (1) *fmttests.werrFmt (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+×
+×
+×
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrFmt (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrFmt
 == Extra "error types"
@@ -1033,7 +1116,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1107,10 +1190,13 @@ Error types: (1) *fmttests.werrFmto (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrFmto (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrFmto
 == Extra "error types"
@@ -1118,7 +1204,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1192,10 +1278,13 @@ Error types: (1) *fmttests.werrFmtoDelegate (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrFmtoDelegate (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrFmtoDelegate
 == Extra "error types"
@@ -1203,7 +1292,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1268,10 +1357,13 @@ Error types: (1) *fmttests.werrFmtp (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrFmtp (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrFmtp
 == Extra "error types"
@@ -1279,7 +1371,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1348,10 +1440,13 @@ Error types: (1) *fmt.wrapError (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmt.wrapError (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmt.wrapError
 == Extra "error types"
@@ -1359,7 +1454,7 @@ errors/*errors.errorString (*::)
 fmt/*fmt.wrapError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1437,24 +1532,24 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*domains.withDomain: error domain: pkg <path> (2)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *errors.errorString
-== Extra "2: details"
-error domain: pkg <path>
+(1) error domain: pkg <path>
+Wraps: (2) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *errors.errorString
+Error types: (1) *domains.withDomain (2) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*domains.withDomain: error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1518,8 +1613,12 @@ Error types: (1) *hintdetail.withHint (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *hintdetail.withHint (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *hintdetail.withHint
 == Extra "error types"
@@ -1527,7 +1626,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withHint (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1593,21 +1692,21 @@ Error types: (1) *issuelink.withIssueLink (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) issue: https://mysite
+  | detail: outerthree
+  | outerfour
+Wraps: (2) ××
 ×
---
+Error types: (1) *issuelink.withIssueLink (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*issuelink.withIssueLink: https://mysite (1)
-(check the extra data payloads)
-== Extra "1: details"
-https://mysite
-outerthree
-   outerfour
+*issuelink.withIssueLink: https://mysite
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/issuelink/*issuelink.withIssueLink (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1667,8 +1766,11 @@ Error types: (1) *fmttests.werrMigrated (2) *errors.errorString
 =====
 == Message payload
 ×
+(1)
+Wraps: (2) ××
 ×
---
+Error types: (1) *fmttests.werrMigrated (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrMigrated
 == Extra "error types"
@@ -1676,7 +1778,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated (some/previous/path/prevpkg.prevType::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1741,22 +1843,21 @@ Error types: (1) *errutil.withPrefix (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-outerthree
-outerfour: ×
+outerthree: ×
+(1) outerthree
+  | outerfour
+Wraps: (2) ××
 ×
---
+Error types: (1) *errutil.withPrefix (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*errutil.withPrefix: outerthree (1)
-(check the extra data payloads)
-== Extra "1: details"
-outerthree
-   outerfour
+*errutil.withPrefix: outerthree
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "outerthree\nouterfour: ×\n×"
+Title: "outerthree: ×"
 (NO STACKTRACE)
 
 run
@@ -1898,18 +1999,48 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 =====
 == Message payload
 <path>:<lineno>: new-style (×
-×) :: ×
-× ::
---
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *errors.errorString
+Wraps: (3) new-style (×
+  | ×) :: ×
+  | × ::
+Wraps: (4) ××
+×
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.withNewMessage (4) *errors.errorString
+-- report composition:
 *errors.errorString
-*errutil.withNewMessage: new-style (× (1)
+*errutil.withNewMessage: new-style (×
 *secondary.withSecondaryError
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style (×
-   ×) :: ×
-   × ::
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withNewMessage (*::)
@@ -1917,7 +2048,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.errorString: new-style (×\n×) :: ×\n× ::\nvia *withstack.withStack"
+Title: "*errors.errorString: new-style (×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2009,10 +2140,13 @@ Error types: (1) *fmttests.werrNoFmt (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrNoFmt (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrNoFmt
 == Extra "error types"
@@ -2020,7 +2154,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2090,8 +2224,11 @@ Error types: (1) *os.LinkError (2) *errors.errorString
 =====
 == Message payload
 link × ×: ×
+(1) link × ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *os.LinkError (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *os.LinkError
 == Extra "error types"
@@ -2099,7 +2236,7 @@ errors/*errors.errorString (*::)
 os/*os.LinkError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "link × ×: ×\n×"
+Title: "link × ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2171,8 +2308,11 @@ Error types: (1) *net.OpError (2) *errors.errorString
 =====
 == Message payload
 send tcp ×: ×
+(1) send tcp ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *net.OpError (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *net.OpError
 == Extra "error types"
@@ -2180,7 +2320,7 @@ errors/*errors.errorString (*::)
 net/*net.OpError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "send tcp ×: ×\n×"
+Title: "send tcp ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2248,8 +2388,11 @@ Error types: (1) *fs.PathError (2) *errors.errorString
 =====
 == Message payload
 link ×: ×
+(1) link ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *fs.PathError (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fs.PathError
 == Extra "error types"
@@ -2257,7 +2400,7 @@ errors/*errors.errorString (*::)
 io/fs/*fs.PathError (os/*os.PathError::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "link ×: ×\n×"
+Title: "link ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2323,8 +2466,11 @@ Error types: (1) *os.SyscallError (2) *errors.errorString
 =====
 == Message payload
 open: ×
+(1) open
+Wraps: (2) ××
 ×
---
+Error types: (1) *os.SyscallError (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *os.SyscallError
 == Extra "error types"
@@ -2332,7 +2478,7 @@ errors/*errors.errorString (*::)
 os/*os.SyscallError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "open: ×\n×"
+Title: "open: ×"
 (NO STACKTRACE)
 
 run
@@ -2414,10 +2560,13 @@ Error types: (1) *errors.withMessage (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *errors.withMessage (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *errors.withMessage
 == Extra "error types"
@@ -2425,7 +2574,7 @@ errors/*errors.errorString (*::)
 github.com/pkg/errors/*errors.withMessage (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2572,8 +2721,36 @@ Error types: (1) *errors.withStack (2) *errors.errorString
 =====
 == Message payload
 <path>:<lineno>: ×
+(1)
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ××
 ×
---
+Error types: (1) *errors.withStack (2) *errors.errorString
+-- report composition:
 *errors.errorString
 <path>:<lineno>: *errors.withStack (top exception)
 == Extra "error types"
@@ -2581,7 +2758,7 @@ errors/*errors.errorString (*::)
 github.com/pkg/errors/*errors.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.errorString: ×\n×\nvia *errors.withStack"
+Title: "*errors.errorString: ×\nvia *errors.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2668,20 +2845,20 @@ Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) safe ×
+  | ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*safedetails.withSafeDetails: safe × (1)
-(check the extra data payloads)
-== Extra "1: details"
-safe ×
-   ×
+*safedetails.withSafeDetails: safe ×
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/safedetails/*safedetails.withSafeDetails (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2746,10 +2923,13 @@ Error types: (1) *fmttests.werrSafeFormat (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-safe ×
-×: ×
+safe ×: ×
+(1) safe ×
+  | ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *fmttests.werrSafeFormat (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrSafeFormat
 == Extra "error types"
@@ -2757,7 +2937,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "safe ×\n×: ×\n×"
+Title: "safe ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2765,7 +2945,6 @@ goerr innerone innertwo
 secondary outerthree outerfour
 
 require (?s)
-----
 ----
 &secondary.withSecondaryError{
     cause:          &errors.errorString{s:"innerone\ninnertwo"},
@@ -2886,50 +3065,50 @@ Error types: (1) *secondary.withSecondaryError (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) secondary error attachment
+  | outerthree
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) outerthree
+  |   | outerfour
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (2) ××
 ×
---
+Error types: (1) *secondary.withSecondaryError (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  outerthree
-   outerfour
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 goerr innerone innertwo
@@ -3040,8 +3219,36 @@ Error types: (1) *withstack.withStack (2) *errors.errorString
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ××
 ×
---
+Error types: (1) *withstack.withStack (2) *errors.errorString
+-- report composition:
 *errors.errorString
 <path>:<lineno>: *withstack.withStack (top exception)
 == Extra "error types"
@@ -3049,7 +3256,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.errorString: ×\n×\nvia *withstack.withStack"
+Title: "*errors.errorString: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3190,20 +3397,19 @@ Error types: (1) *contexttags.withContext (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) tags: [k×,safe=456]
+Wraps: (2) ××
 ×
---
+Error types: (1) *contexttags.withContext (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*contexttags.withContext: k× (1)
-(check the extra data payloads)
-== Extra "1: details"
-k×
-safe=456
+*contexttags.withContext: k×
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/contexttags/*contexttags.withContext (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3267,21 +3473,20 @@ Error types: (1) *telemetrykeys.withTelemetry (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) keys: [somekey outerthree
+  | outerfour]
+Wraps: (2) ××
 ×
---
+Error types: (1) *telemetrykeys.withTelemetry (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*telemetrykeys.withTelemetry: somekey (1)
-(check the extra data payloads)
-== Extra "1: details"
-somekey
-outerthree
-   outerfour
+*telemetrykeys.withTelemetry: somekey
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3404,24 +3609,49 @@ Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *errors.errorS
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-stylew ×
-×: ×
+<path>:<lineno>: new-stylew ×: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) new-stylew ×
+  | ×
+Wraps: (3) ××
 ×
---
+Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *errors.errorString
+-- report composition:
 *errors.errorString
-*errutil.withPrefix: new-stylew × (1)
+*errutil.withPrefix: new-stylew ×
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-stylew ×
-   ×
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.errorString: new-stylew ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*errors.errorString: new-stylew ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3452,7 +3682,6 @@ goerr innerone innertwo
 wrapf-attached outerthree outerfour
 
 require (?s)outerthree.*outerfour.*
-----
 ----
 &withstack.withStack{
     cause: &secondary.withSecondaryError{
@@ -3640,47 +3869,73 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-style ×
-× (payload): ×
+<path>:<lineno>: new-style ×: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | payload
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | × (payload)
+Wraps: (4) ××
 ×
---
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.withPrefix (4) *errors.errorString
+-- report composition:
 *errors.errorString
-*errutil.withPrefix: new-style × (1)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
+*errutil.withPrefix: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   × (payload)
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -3688,7 +3943,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.errorString: new-style ×\n× (payload): ×\n×\nvia *withstack.withStack"
+Title: "*errors.errorString: new-style ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3713,5 +3968,3 @@ Title: "*errors.errorString: new-style ×\n× (payload): ×\n×\nvia *withstack.
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----

--- a/fmttests/testdata/format/wrap-goerr-via-network
+++ b/fmttests/testdata/format/wrap-goerr-via-network
@@ -150,9 +150,15 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *ba
 <path>:<lineno>: ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *errors.errorString
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -350,12 +356,17 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *er
 ×: ×
 ×
 --
-*barriers.barrierError
-*errutil.withPrefix: assertmsg: × (1)
+*barriers.barrierError: masked error: × (1)
+*errutil.withPrefix: assertmsg: × (2)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *errors.errorString
+== Extra "2: details"
 assertmsg: ×
    ×
 == Extra "error types"
@@ -461,7 +472,13 @@ Error types: (1) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *errors.errorString
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
@@ -1613,10 +1630,15 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
-*domains.withDomain: error domain: pkg <path> (1)
+*barriers.barrierError: masked error: × (1)
+*domains.withDomain: error domain: pkg <path> (2)
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *errors.errorString
+== Extra "2: details"
 error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)

--- a/fmttests/testdata/format/wrap-goerr-via-network
+++ b/fmttests/testdata/format/wrap-goerr-via-network
@@ -148,24 +148,55 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *ba
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
-*barriers.barrierError: masked error: × (1)
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *errors.errorString
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *errors.errorString
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -352,23 +383,52 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *er
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×
-×: ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*errutil.withPrefix: assertmsg: × (2)
+<path>:<lineno>: assertmsg: ×: ×
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg: ×
+  | ×
+Wraps: (4) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *errors.errorString
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *errors.errorString
-== Extra "2: details"
-assertmsg: ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -376,7 +436,7 @@ github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -470,20 +530,21 @@ Error types: (1) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *errors.errorString
+(1) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *errors.errorString
+Error types: (1) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -567,10 +628,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrDelegate
 == Extra "error types"
@@ -578,7 +645,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -657,8 +724,13 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 =====
 == Message payload
 ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrDelegateEmpty
 == Extra "error types"
@@ -666,7 +738,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -745,8 +817,13 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 =====
 == Message payload
 ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrDelegateNoPrefix
 == Extra "error types"
@@ -754,7 +831,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -819,8 +896,12 @@ Error types: (1) *hintdetail.withDetail (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *hintdetail.withDetail (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *hintdetail.withDetail
 == Extra "error types"
@@ -828,7 +909,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withDetail (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -891,19 +972,19 @@ Error types: (1) *domains.withDomain (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) mydomain
+Wraps: (2) ××
 ×
---
+Error types: (1) *domains.withDomain (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*domains.withDomain: mydomain (1)
-(check the extra data payloads)
-== Extra "1: details"
-mydomain
+*domains.withDomain: mydomain
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::mydomain)
 == Exception 1 (Module: "mydomain")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -968,8 +1049,12 @@ Error types: (1) *fmttests.werrWithElidedCause (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrWithElidedCause (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrWithElidedCause
 == Extra "error types"
@@ -977,7 +1062,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrWithElidedCause (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1056,8 +1141,13 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 =====
 == Message payload
 ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrEmpty
 == Extra "error types"
@@ -1065,7 +1155,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1149,10 +1239,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrFmt
 == Extra "error types"
@@ -1160,7 +1256,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1247,10 +1343,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrFmto
 == Extra "error types"
@@ -1258,7 +1360,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1345,10 +1447,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrFmtoDelegate
 == Extra "error types"
@@ -1356,7 +1464,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1440,10 +1548,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrFmtp
 == Extra "error types"
@@ -1451,7 +1565,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1538,10 +1652,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: fmt/*fmt.wrapError
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmt.wrapError
 == Extra "error types"
@@ -1549,7 +1669,7 @@ errors/*errors.errorString (*::)
 fmt/*fmt.wrapError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1628,24 +1748,24 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*domains.withDomain: error domain: pkg <path> (2)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *errors.errorString
-== Extra "2: details"
-error domain: pkg <path>
+(1) error domain: pkg <path>
+Wraps: (2) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *errors.errorString
+Error types: (1) *domains.withDomain (2) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*domains.withDomain: error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1710,8 +1830,12 @@ Error types: (1) *hintdetail.withHint (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *hintdetail.withHint (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *hintdetail.withHint
 == Extra "error types"
@@ -1719,7 +1843,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withHint (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1786,21 +1910,21 @@ Error types: (1) *issuelink.withIssueLink (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) issue: https://mysite
+  | detail: outerthree
+  | outerfour
+Wraps: (2) ××
 ×
---
+Error types: (1) *issuelink.withIssueLink (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*issuelink.withIssueLink: https://mysite (1)
-(check the extra data payloads)
-== Extra "1: details"
-https://mysite
-outerthree
-   outerfour
+*issuelink.withIssueLink: https://mysite
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/issuelink/*issuelink.withIssueLink (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1879,8 +2003,13 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 =====
 == Message payload
 ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrMigrated
 == Extra "error types"
@@ -1888,7 +2017,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated (some/previous/path/prevpkg.prevType::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1954,22 +2083,21 @@ Error types: (1) *errutil.withPrefix (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-outerthree
-outerfour: ×
+outerthree: ×
+(1) outerthree
+  | outerfour
+Wraps: (2) ××
 ×
---
+Error types: (1) *errutil.withPrefix (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*errutil.withPrefix: outerthree (1)
-(check the extra data payloads)
-== Extra "1: details"
-outerthree
-   outerfour
+*errutil.withPrefix: outerthree
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "outerthree\nouterfour: ×\n×"
+Title: "outerthree: ×"
 (NO STACKTRACE)
 
 run
@@ -2130,18 +2258,51 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 =====
 == Message payload
 <path>:<lineno>: new-style (×
-×) :: ×
-× ::
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *errors.errorString
+Wraps: (3) new-style (×
+  | ×) :: ×
+  | × ::
+Wraps: (4) ××
+×
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.withNewMessage (4) *errors.errorString
+-- report composition:
 *errors.errorString
-*errutil.withNewMessage: new-style (× (1)
+*errutil.withNewMessage: new-style (×
 *secondary.withSecondaryError
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style (×
-   ×) :: ×
-   × ::
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withNewMessage (*::)
@@ -2149,7 +2310,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.errorString: new-style (×\n×) :: ×\n× ::\nvia *withstack.withStack"
+Title: "*errors.errorString: new-style (×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2259,10 +2420,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrNoFmt
 == Extra "error types"
@@ -2270,7 +2437,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2341,8 +2508,11 @@ Error types: (1) *os.LinkError (2) *errors.errorString
 =====
 == Message payload
 link × ×: ×
+(1) link × ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *os.LinkError (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *os.LinkError
 == Extra "error types"
@@ -2350,7 +2520,7 @@ errors/*errors.errorString (*::)
 os/*os.LinkError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "link × ×: ×\n×"
+Title: "link × ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2434,8 +2604,14 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 =====
 == Message payload
 ×: ×
+(1) ×
+  |
+  | (opaque error wrapper)
+  | type name: net/*net.OpError
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *net.OpError
 == Extra "error types"
@@ -2443,7 +2619,7 @@ errors/*errors.errorString (*::)
 net/*net.OpError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2512,8 +2688,11 @@ Error types: (1) *fs.PathError (2) *errors.errorString
 =====
 == Message payload
 link ×: ×
+(1) link ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *fs.PathError (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fs.PathError
 == Extra "error types"
@@ -2521,7 +2700,7 @@ errors/*errors.errorString (*::)
 io/fs/*fs.PathError (os/*os.PathError::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "link ×: ×\n×"
+Title: "link ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2588,8 +2767,11 @@ Error types: (1) *os.SyscallError (2) *errors.errorString
 =====
 == Message payload
 open: ×
+(1) open
+Wraps: (2) ××
 ×
---
+Error types: (1) *os.SyscallError (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *os.SyscallError
 == Extra "error types"
@@ -2597,7 +2779,7 @@ errors/*errors.errorString (*::)
 os/*os.SyscallError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "open: ×\n×"
+Title: "open: ×"
 (NO STACKTRACE)
 
 run
@@ -2680,10 +2862,13 @@ Error types: (1) *errors.withMessage (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *errors.withMessage (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *errors.withMessage
 == Extra "error types"
@@ -2691,7 +2876,7 @@ errors/*errors.errorString (*::)
 github.com/pkg/errors/*errors.withMessage (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2827,8 +3012,39 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 =====
 == Message payload
 <path>:<lineno>: ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/pkg/errors/*errors.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 <path>:<lineno>: *errors.withStack (top exception)
 == Extra "error types"
@@ -2836,7 +3052,7 @@ errors/*errors.errorString (*::)
 github.com/pkg/errors/*errors.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.errorString: ×\n×\nvia *errors.withStack"
+Title: "*errors.errorString: ×\nvia *errors.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2924,20 +3140,20 @@ Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) safe ×
+  | ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *safedetails.withSafeDetails (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*safedetails.withSafeDetails: safe × (1)
-(check the extra data payloads)
-== Extra "1: details"
-safe ×
-   ×
+*safedetails.withSafeDetails: safe ×
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/safedetails/*safedetails.withSafeDetails (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3021,10 +3237,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 *fmttests.werrSafeFormat
 == Extra "error types"
@@ -3032,7 +3254,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -3041,7 +3263,6 @@ secondary outerthree outerfour
 opaque
 
 require (?s)innerone.*innertwo
-----
 ----
 &secondary.withSecondaryError{
     cause:          &errors.errorString{s:"innerone\ninnertwo"},
@@ -3180,50 +3401,53 @@ Error types: (1) *secondary.withSecondaryError (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) secondary error attachment
+  | outerthree
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) outerthree
+  |   | outerfour
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (2) ××
 ×
---
+Error types: (1) *secondary.withSecondaryError (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  outerthree
-   outerfour
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 goerr innerone innertwo
@@ -3353,8 +3577,39 @@ Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
 =====
 == Message payload
 <path>:<lineno>: ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errors.errorString
+-- report composition:
 *errors.errorString
 <path>:<lineno>: *withstack.withStack (top exception)
 == Extra "error types"
@@ -3362,7 +3617,7 @@ errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.errorString: ×\n×\nvia *withstack.withStack"
+Title: "*errors.errorString: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3496,20 +3751,19 @@ Error types: (1) *contexttags.withContext (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) tags: [k×,safe=×]
+Wraps: (2) ××
 ×
---
+Error types: (1) *contexttags.withContext (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*contexttags.withContext: k× (1)
-(check the extra data payloads)
-== Extra "1: details"
-k×
-safe=456
+*contexttags.withContext: k×
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/contexttags/*contexttags.withContext (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3574,21 +3828,20 @@ Error types: (1) *telemetrykeys.withTelemetry (2) *errors.errorString
 =====
 == Message payload
 ×
+(1) keys: [somekey outerthree
+  | outerfour]
+Wraps: (2) ××
 ×
---
+Error types: (1) *telemetrykeys.withTelemetry (2) *errors.errorString
+-- report composition:
 *errors.errorString
-*telemetrykeys.withTelemetry: somekey (1)
-(check the extra data payloads)
-== Extra "1: details"
-somekey
-outerthree
-   outerfour
+*telemetrykeys.withTelemetry: somekey
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*errors.errorString"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3730,24 +3983,52 @@ Error types: (1) *errbase.opaqueWrapper (2) *errutil.withPrefix (3) *errors.erro
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-stylew ×
-×: ×
+<path>:<lineno>: new-stylew ×: ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) new-stylew ×
+  | ×
+Wraps: (3) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *errutil.withPrefix (3) *errors.errorString
+-- report composition:
 *errors.errorString
-*errutil.withPrefix: new-stylew × (1)
+*errutil.withPrefix: new-stylew ×
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-stylew ×
-   ×
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.errorString: new-stylew ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*errors.errorString: new-stylew ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3779,7 +4060,6 @@ wrapf-attached outerthree outerfour
 opaque
 
 require (?s)outerthree.*outerfour.*innerone.*innertwo
-----
 ----
 &errbase.opaqueWrapper{
     cause: &secondary.withSecondaryError{
@@ -4003,47 +4283,79 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-style ×
-× (payload): ×
+<path>:<lineno>: new-style ×: ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | payload
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | × (payload)
+Wraps: (4) ××
 ×
---
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.withPrefix (4) *errors.errorString
+-- report composition:
 *errors.errorString
-*errutil.withPrefix: new-style × (1)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
+*errutil.withPrefix: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   × (payload)
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 errors/*errors.errorString (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -4051,7 +4363,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.errorString: new-style ×\n× (payload): ×\n×\nvia *withstack.withStack"
+Title: "*errors.errorString: new-style ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4076,5 +4388,3 @@ Title: "*errors.errorString: new-style ×\n× (payload): ×\n×\nvia *withstack.
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----

--- a/fmttests/testdata/format/wrap-goerr-via-network
+++ b/fmttests/testdata/format/wrap-goerr-via-network
@@ -7,8 +7,8 @@ require (?s)innerone.*innertwo
 ----
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
         },
         prefix:  "",
@@ -26,8 +26,8 @@ require (?s)innerone.*innertwo
 == %#v
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
         },
         prefix:  "",
@@ -86,7 +86,7 @@ Wraps: (3) innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -142,7 +142,7 @@ Wraps: (3) ‹innerone›
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -185,18 +185,18 @@ Wraps: (3) ×
   | (1) ××
   | ×
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -232,8 +232,8 @@ require (?s)outerthree.*outerfour.*innerone.*innertwo
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
             },
             prefix: "assertmsg: ‹outerthree›\n‹outerfour›",
@@ -254,8 +254,8 @@ require (?s)outerthree.*outerfour.*innerone.*innertwo
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
             },
             prefix: "assertmsg: ‹outerthree›\n‹outerfour›",
@@ -319,7 +319,7 @@ Wraps: (4) innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -378,7 +378,7 @@ Wraps: (4) ‹innerone›
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -423,20 +423,20 @@ Wraps: (4) ×
   | (1) ××
   | ×
   | Error types: (1) *errors.errorString
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -469,16 +469,16 @@ opaque
 
 require (?s)innerone.*innertwo
 ----
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
 }
 =====
 ===== non-redactable formats
 =====
 == %#v
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
 }
 == Error()
@@ -498,7 +498,7 @@ innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *errors.errorString
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -524,7 +524,7 @@ Error types: (1) *barriers.barrierError
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *errors.errorString
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -537,13 +537,13 @@ Error types: (1) *barriers.barrierError
   | (1) ××
   | ×
   | Error types: (1) *errors.errorString
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 
@@ -1680,8 +1680,8 @@ opaque
 require (?s)innerone.*innertwo
 ----
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
     },
     domain: "error domain: pkg <path>",
@@ -1691,8 +1691,8 @@ require (?s)innerone.*innertwo
 =====
 == %#v
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errors.errorString{s:"innerone\ninnertwo"},
     },
     domain: "error domain: pkg <path>",
@@ -1715,7 +1715,7 @@ Wraps: (2) innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *errors.errorString
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -1742,7 +1742,7 @@ Wraps: (2) ‹innerone›
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *errors.errorString
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -1756,15 +1756,15 @@ Wraps: (2) ×
   | (1) ××
   | ×
   | Error types: (1) *errors.errorString
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *domains.withDomain: error domain: pkg <path>
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 

--- a/fmttests/testdata/format/wrap-newf
+++ b/fmttests/testdata/format/wrap-newf
@@ -6,8 +6,8 @@ require (?s)
 ----
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
-        cause: &barriers.barrierError{
-            msg:       "new-style innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "new-style ‹innerone›\n‹innertwo›",
             maskedErr: &withstack.withStack{
                 cause: &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
                 stack: &stack{...},
@@ -22,8 +22,8 @@ require (?s)
 == %#v
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
-        cause: &barriers.barrierError{
-            msg:       "new-style innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "new-style ‹innerone›\n‹innertwo›",
             maskedErr: &withstack.withStack{
                 cause: &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
                 stack: &stack{...},
@@ -102,7 +102,7 @@ Wraps: (3) new-style innerone
   | Wraps: (2) new-style innerone
   |   | innertwo
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -112,7 +112,7 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barr
 ===== redactable formats
 =====
 == printed via redact Print(), ok - congruent with %v
-‹new-style innerone›
+new-style ‹innerone›
 ‹innertwo›
 == printed via redact Printf() %v = Print(), good
 == printed via redact Printf() %s = Print(), good
@@ -120,7 +120,7 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barr
 == printed via redact Printf() %x, refused - good
 == printed via redact Printf() %X, refused - good
 == printed via redact Printf() %+v, ok - congruent with %+v
-‹new-style innerone›
+new-style ‹innerone›
 (1) assertion failure
 Wraps: (2) attached stack trace
   -- stack trace:
@@ -148,7 +148,7 @@ Wraps: (2) attached stack trace
   | <tab><path>:<lineno>
   | runtime.goexit
   | <tab><path>:<lineno>
-Wraps: (3) ‹new-style innerone›
+Wraps: (3) new-style ‹innerone›
   | ‹innertwo›
   | -- cause hidden behind barrier
   | new-style ‹innerone›
@@ -181,12 +181,12 @@ Wraps: (3) ‹new-style innerone›
   | Wraps: (2) new-style ‹innerone›
   |   | ‹innertwo›
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
+<path>:<lineno>: new-style ×
 (1) assertion failure
 Wraps: (2) attached stack trace
   -- stack trace:
@@ -214,7 +214,7 @@ Wraps: (2) attached stack trace
   | <tab><path>:<lineno>
   | runtime.goexit
   | <tab><path>:<lineno>
-Wraps: (3) ×
+Wraps: (3) new-style ×
   | ×
   | -- cause hidden behind barrier
   | new-style ×
@@ -247,18 +247,18 @@ Wraps: (3) ×
   | Wraps: (2) new-style ×
   |   | ×
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*barriers.barrierErr: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -293,8 +293,8 @@ require (?s)outerthree.*outerfour.*
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "new-style innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "new-style ‹innerone›\n‹innertwo›",
                 maskedErr: &withstack.withStack{
                     cause: &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
                     stack: &stack{...},
@@ -312,8 +312,8 @@ require (?s)outerthree.*outerfour.*
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "new-style innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "new-style ‹innerone›\n‹innertwo›",
                 maskedErr: &withstack.withStack{
                     cause: &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
                     stack: &stack{...},
@@ -397,7 +397,7 @@ Wraps: (4) new-style innerone
   | Wraps: (2) new-style innerone
   |   | innertwo
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -408,7 +408,7 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *erru
 =====
 == printed via redact Print(), ok - congruent with %v
 assertmsg: ‹outerthree›
-‹outerfour›: ‹new-style innerone›
+‹outerfour›: new-style ‹innerone›
 ‹innertwo›
 == printed via redact Printf() %v = Print(), good
 == printed via redact Printf() %s = Print(), good
@@ -416,7 +416,7 @@ assertmsg: ‹outerthree›
 == printed via redact Printf() %x, refused - good
 == printed via redact Printf() %X, refused - good
 == printed via redact Printf() %+v, ok - congruent with %+v
-assertmsg: ‹outerthree›: ‹new-style innerone›
+assertmsg: ‹outerthree›: new-style ‹innerone›
 (1) assertion failure
 Wraps: (2) attached stack trace
   -- stack trace:
@@ -446,7 +446,7 @@ Wraps: (2) attached stack trace
   | <tab><path>:<lineno>
 Wraps: (3) assertmsg: ‹outerthree›
   | ‹outerfour›
-Wraps: (4) ‹new-style innerone›
+Wraps: (4) new-style ‹innerone›
   | ‹innertwo›
   | -- cause hidden behind barrier
   | new-style ‹innerone›
@@ -479,12 +479,12 @@ Wraps: (4) ‹new-style innerone›
   | Wraps: (2) new-style ‹innerone›
   |   | ‹innertwo›
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×: ×
+<path>:<lineno>: assertmsg: ×: new-style ×
 (1) assertion failure
 Wraps: (2) attached stack trace
   -- stack trace:
@@ -514,7 +514,7 @@ Wraps: (2) attached stack trace
   | <tab><path>:<lineno>
 Wraps: (3) assertmsg: ×
   | ×
-Wraps: (4) ×
+Wraps: (4) new-style ×
   | ×
   | -- cause hidden behind barrier
   | new-style ×
@@ -547,20 +547,20 @@ Wraps: (4) ×
   | Wraps: (2) new-style ×
   |   | ×
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*barriers.barrierErr: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 *errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: assertmsg: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -592,8 +592,8 @@ barrier outerthree outerfour
 
 require (?s)
 ----
-&barriers.barrierError{
-    msg:       "new-style innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "new-style ‹innerone›\n‹innertwo›",
     maskedErr: &withstack.withStack{
         cause: &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
         stack: &stack{...},
@@ -603,8 +603,8 @@ require (?s)
 ===== non-redactable formats
 =====
 == %#v
-&barriers.barrierError{
-    msg:       "new-style innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "new-style ‹innerone›\n‹innertwo›",
     maskedErr: &withstack.withStack{
         cause: &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
         stack: &stack{...},
@@ -653,7 +653,7 @@ new-style innerone
   | Wraps: (2) new-style innerone
   |   | innertwo
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -663,7 +663,7 @@ Error types: (1) *barriers.barrierError
 ===== redactable formats
 =====
 == printed via redact Print(), ok - congruent with %v
-‹new-style innerone›
+new-style ‹innerone›
 ‹innertwo›
 == printed via redact Printf() %v = Print(), good
 == printed via redact Printf() %s = Print(), good
@@ -671,8 +671,8 @@ Error types: (1) *barriers.barrierError
 == printed via redact Printf() %x, refused - good
 == printed via redact Printf() %X, refused - good
 == printed via redact Printf() %+v, ok - congruent with %+v
-‹new-style innerone›
-(1) ‹new-style innerone›
+new-style ‹innerone›
+(1) new-style ‹innerone›
   | ‹innertwo›
   | -- cause hidden behind barrier
   | new-style ‹innerone›
@@ -705,13 +705,13 @@ Error types: (1) *barriers.barrierError
   | Wraps: (2) new-style ‹innerone›
   |   | ‹innertwo›
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
 == Message payload
-×
-(1) ×
+new-style ×
+(1) new-style ×
   | ×
   | -- cause hidden behind barrier
   | new-style ×
@@ -744,14 +744,14 @@ Error types: (1) *barriers.barrierError
   | Wraps: (2) new-style ×
   |   | ×
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*barriers.barrierErr: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "*barriers.barrierError"
-Title: "×"
+Type: "*barriers.barrierErr"
+Title: "new-style ×"
 (NO STACKTRACE)
 
 run
@@ -3080,8 +3080,8 @@ handled-domain outerthree outerfour
 require (?s)
 ----
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "new-style innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "new-style ‹innerone›\n‹innertwo›",
         maskedErr: &withstack.withStack{
             cause: &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
             stack: &stack{...},
@@ -3094,8 +3094,8 @@ require (?s)
 =====
 == %#v
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "new-style innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "new-style ‹innerone›\n‹innertwo›",
         maskedErr: &withstack.withStack{
             cause: &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
             stack: &stack{...},
@@ -3147,7 +3147,7 @@ Wraps: (2) new-style innerone
   | Wraps: (2) new-style innerone
   |   | innertwo
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -3157,7 +3157,7 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 ===== redactable formats
 =====
 == printed via redact Print(), ok - congruent with %v
-‹new-style innerone›
+new-style ‹innerone›
 ‹innertwo›
 == printed via redact Printf() %v = Print(), good
 == printed via redact Printf() %s = Print(), good
@@ -3165,9 +3165,9 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 == printed via redact Printf() %x, refused - good
 == printed via redact Printf() %X, refused - good
 == printed via redact Printf() %+v, ok - congruent with %+v
-‹new-style innerone›
+new-style ‹innerone›
 (1) error domain: pkg <path>
-Wraps: (2) ‹new-style innerone›
+Wraps: (2) new-style ‹innerone›
   | ‹innertwo›
   | -- cause hidden behind barrier
   | new-style ‹innerone›
@@ -3200,14 +3200,14 @@ Wraps: (2) ‹new-style innerone›
   | Wraps: (2) new-style ‹innerone›
   |   | ‹innertwo›
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
 == Message payload
-×
+new-style ×
 (1) error domain: pkg <path>
-Wraps: (2) ×
+Wraps: (2) new-style ×
   | ×
   | -- cause hidden behind barrier
   | new-style ×
@@ -3240,16 +3240,16 @@ Wraps: (2) ×
   | Wraps: (2) new-style ×
   |   | ×
   | Error types: (1) *withstack.withStack (2) *errutil.leafError
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*barriers.barrierErr: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 *domains.withDomain: error domain: pkg <path>
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
-Type: "*barriers.barrierError"
-Title: "×"
+Type: "*barriers.barrierErr"
+Title: "new-style ×"
 (NO STACKTRACE)
 
 run

--- a/fmttests/testdata/format/wrap-newf
+++ b/fmttests/testdata/format/wrap-newf
@@ -224,6 +224,36 @@ details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
   new-style ×
    ×
+masked error: new-style ×
+   (1) attached stack trace
+     -- stack trace:
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Wraps: (2) new-style ×
+     | ×
+   Error types: (1) *withstack.withStack (2) *errutil.leafError
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -498,6 +528,36 @@ details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
   new-style ×
    ×
+masked error: new-style ×
+   (1) attached stack trace
+     -- stack trace:
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Wraps: (2) new-style ×
+     | ×
+   Error types: (1) *withstack.withStack (2) *errutil.leafError
 == Extra "2: details"
 assertmsg: ×
    ×
@@ -696,6 +756,36 @@ details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
   new-style ×
    ×
+masked error: new-style ×
+   (1) attached stack trace
+     -- stack trace:
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Wraps: (2) new-style ×
+     | ×
+   Error types: (1) *withstack.withStack (2) *errutil.leafError
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
@@ -2888,6 +2978,36 @@ details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
   new-style ×
    ×
+masked error: new-style ×
+   (1) attached stack trace
+     -- stack trace:
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Wraps: (2) new-style ×
+     | ×
+   Error types: (1) *withstack.withStack (2) *errutil.leafError
 == Extra "2: details"
 error domain: pkg <path>
 == Extra "error types"

--- a/fmttests/testdata/format/wrap-newf
+++ b/fmttests/testdata/format/wrap-newf
@@ -4,7 +4,6 @@ assertion outerthree outerfour
 
 require (?s)
 ----
-----
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &barriers.barrierError{
@@ -188,79 +187,78 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barr
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) ×
+  | ×
+  | -- cause hidden behind barrier
+  | new-style ×
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) new-style ×
+  |   | ×
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  new-style ×
-   ×
-masked error: new-style ×
-   (1) attached stack trace
-     -- stack trace:
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Wraps: (2) new-style ×
-     | ×
-   Error types: (1) *withstack.withStack (2) *errutil.leafError
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -285,15 +283,12 @@ Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 newf innerone innertwo
 assertwrap outerthree outerfour
 
 require (?s)outerthree.*outerfour.*
-----
 ----
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
@@ -489,78 +484,75 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *erru
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×
-×: ×
-×
---
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-*errutil.withPrefix: assertmsg: × (2)
+<path>:<lineno>: assertmsg: ×: ×
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg: ×
+  | ×
+Wraps: (4) ×
+  | ×
+  | -- cause hidden behind barrier
+  | new-style ×
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) new-style ×
+  |   | ×
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  new-style ×
-   ×
-masked error: new-style ×
-   (1) attached stack trace
-     -- stack trace:
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Wraps: (2) new-style ×
-     | ×
-   Error types: (1) *withstack.withStack (2) *errutil.leafError
-== Extra "2: details"
-assertmsg: ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -568,7 +560,7 @@ github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -593,15 +585,12 @@ Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withSt
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 newf innerone innertwo
 barrier outerthree outerfour
 
 require (?s)
-----
 ----
 &barriers.barrierError{
     msg:       "new-style innerone\ninnertwo",
@@ -722,78 +711,48 @@ Error types: (1) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  new-style ×
-   ×
-masked error: new-style ×
-   (1) attached stack trace
-     -- stack trace:
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Wraps: (2) new-style ×
-     | ×
-   Error types: (1) *withstack.withStack (2) *errutil.leafError
+(1) ×
+  | ×
+  | -- cause hidden behind barrier
+  | new-style ×
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) new-style ×
+  |   | ×
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Error types: (1) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 newf innerone innertwo
@@ -919,24 +878,51 @@ Error types: (1) *fmttests.werrDelegate (2) *withstack.withStack (3) *errutil.le
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
+<path>:<lineno>: ×: new-style ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+×
+×
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrDelegate (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrDelegate
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1077,22 +1063,47 @@ Error types: (1) *fmttests.werrDelegateEmpty (2) *withstack.withStack (3) *errut
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrDelegateEmpty (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrDelegateEmpty
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1233,22 +1244,47 @@ Error types: (1) *fmttests.werrDelegateNoPrefix (2) *withstack.withStack (3) *er
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) ×
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrDelegateNoPrefix (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrDelegateNoPrefix
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1393,22 +1429,48 @@ Error types: (1) *hintdetail.withDetail (2) *withstack.withStack (3) *errutil.le
 =====
 == Message payload
 <path>:<lineno>: new-style ×
+(1) ×
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *hintdetail.withDetail (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *hintdetail.withDetail
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withDetail (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1551,24 +1613,47 @@ Error types: (1) *domains.withDomain (2) *withstack.withStack (3) *errutil.leafE
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) mydomain
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *domains.withDomain (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*domains.withDomain: mydomain (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-mydomain
+*domains.withDomain: mydomain
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::mydomain)
 == Exception 1 (Module: "mydomain")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1713,22 +1798,48 @@ Error types: (1) *fmttests.werrWithElidedCause (2) *withstack.withStack (3) *err
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrWithElidedCause (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrWithElidedCause
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrWithElidedCause (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1869,22 +1980,47 @@ Error types: (1) *fmttests.werrEmpty (2) *withstack.withStack (3) *errutil.leafE
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrEmpty (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrEmpty
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2036,24 +2172,52 @@ Error types: (1) *fmttests.werrFmt (2) *withstack.withStack (3) *errutil.leafErr
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
+<path>:<lineno>: ×: new-style ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+×
+×
+×
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrFmt (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrFmt
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2236,24 +2400,49 @@ Error types: (1) *fmttests.werrFmto (2) *withstack.withStack (3) *errutil.leafEr
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
+<path>:<lineno>: ×: new-style ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrFmto (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrFmto
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2436,24 +2625,49 @@ Error types: (1) *fmttests.werrFmtoDelegate (2) *withstack.withStack (3) *erruti
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
+<path>:<lineno>: ×: new-style ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrFmtoDelegate (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrFmtoDelegate
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2599,24 +2813,49 @@ Error types: (1) *fmttests.werrFmtp (2) *withstack.withStack (3) *errutil.leafEr
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
+<path>:<lineno>: ×: new-style ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrFmtp (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrFmtp
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2766,24 +3005,49 @@ Error types: (1) *fmt.wrapError (2) *withstack.withStack (3) *errutil.leafError
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
+<path>:<lineno>: ×: new-style ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmt.wrapError (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmt.wrapError
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 fmt/*fmt.wrapError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2814,7 +3078,6 @@ newf innerone innertwo
 handled-domain outerthree outerfour
 
 require (?s)
-----
 ----
 &domains.withDomain{
     cause: &barriers.barrierError{
@@ -2943,82 +3206,51 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-*domains.withDomain: error domain: pkg <path> (2)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  new-style ×
-   ×
-masked error: new-style ×
-   (1) attached stack trace
-     -- stack trace:
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Wraps: (2) new-style ×
-     | ×
-   Error types: (1) *withstack.withStack (2) *errutil.leafError
-== Extra "2: details"
-error domain: pkg <path>
+(1) error domain: pkg <path>
+Wraps: (2) ×
+  | ×
+  | -- cause hidden behind barrier
+  | new-style ×
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) new-style ×
+  |   | ×
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Error types: (1) *domains.withDomain (2) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*domains.withDomain: error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 newf innerone innertwo
@@ -3139,22 +3371,48 @@ Error types: (1) *hintdetail.withHint (2) *withstack.withStack (3) *errutil.leaf
 =====
 == Message payload
 <path>:<lineno>: new-style ×
+(1) ×
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *hintdetail.withHint (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *hintdetail.withHint
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withHint (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3301,26 +3559,49 @@ Error types: (1) *issuelink.withIssueLink (2) *withstack.withStack (3) *errutil.
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) issue: https://mysite
+  | detail: outerthree
+  | outerfour
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *issuelink.withIssueLink (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*issuelink.withIssueLink: https://mysite (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-https://mysite
-outerthree
-   outerfour
+*issuelink.withIssueLink: https://mysite
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/issuelink/*issuelink.withIssueLink (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3461,22 +3742,47 @@ Error types: (1) *fmttests.werrMigrated (2) *withstack.withStack (3) *errutil.le
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrMigrated (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrMigrated
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated (some/previous/path/prevpkg.prevType::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3622,27 +3928,49 @@ Error types: (1) *errutil.withPrefix (2) *withstack.withStack (3) *errutil.leafE
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: outerthree
-outerfour: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: outerthree: new-style ×
+(1) outerthree
+  | outerfour
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errutil.withPrefix (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*errutil.withPrefix: outerthree (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-outerthree
-   outerfour
+*errutil.withPrefix: outerthree
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: outerthree\nouterfour: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: outerthree: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3673,7 +4001,6 @@ newf innerone innertwo
 newfw outerthree outerfour
 
 require (?s)outerthree.*outerfour.*
-----
 ----
 &withstack.withStack{
     cause: &secondary.withSecondaryError{
@@ -3882,52 +4209,81 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 =====
 == Message payload
 <path>:<lineno>: new-style (×
-×) :: new-style ×
-× ::
---
-*errutil.leafError: new-style × (1)
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) secondary error attachment
+  | new-style ×
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) new-style ×
+  |   | ×
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (3) new-style (×
+  | ×) :: new-style ×
+  | × ::
+Wraps: (4) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (5) new-style ×
+  | ×
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.withNewMessage (4) *withstack.withStack (5) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*errutil.withNewMessage: new-style (× (2)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (3)
-<path>:<lineno>: *withstack.withStack (4)
+*errutil.withNewMessage: new-style (×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-new-style (×
-   ×) :: new-style ×
-   × ::
-== Extra "3: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -3935,7 +4291,7 @@ github.com/cockroachdb/errors/errutil/*errutil.withNewMessage (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(4) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -3963,7 +4319,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style (×\n×) :: new-style ×\n× ::\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style (×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3988,8 +4344,6 @@ Title: "*errutil.leafError: new-style (×\n×) :: new-style ×\n× ::\nvia *with
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 newf innerone innertwo
@@ -4115,24 +4469,49 @@ Error types: (1) *fmttests.werrNoFmt (2) *withstack.withStack (3) *errutil.leafE
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
+<path>:<lineno>: ×: new-style ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrNoFmt (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrNoFmt
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4286,22 +4665,47 @@ Error types: (1) *os.LinkError (2) *withstack.withStack (3) *errutil.leafError
 =====
 == Message payload
 <path>:<lineno>: link × ×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) link × ×
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *os.LinkError (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *os.LinkError
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 os/*os.LinkError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: link × ×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: link × ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4457,22 +4861,47 @@ Error types: (1) *net.OpError (2) *withstack.withStack (3) *errutil.leafError
 =====
 == Message payload
 <path>:<lineno>: send tcp ×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) send tcp ×
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *net.OpError (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *net.OpError
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 net/*net.OpError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: send tcp ×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: send tcp ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4624,22 +5053,47 @@ Error types: (1) *fs.PathError (2) *withstack.withStack (3) *errutil.leafError
 =====
 == Message payload
 <path>:<lineno>: link ×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) link ×
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fs.PathError (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fs.PathError
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 io/fs/*fs.PathError (os/*os.PathError::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: link ×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: link ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4789,22 +5243,47 @@ Error types: (1) *os.SyscallError (2) *withstack.withStack (3) *errutil.leafErro
 =====
 == Message payload
 <path>:<lineno>: open: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) open
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *os.SyscallError (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *os.SyscallError
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 os/*os.SyscallError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: open: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: open: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4995,24 +5474,49 @@ Error types: (1) *errors.withMessage (2) *withstack.withStack (3) *errutil.leafE
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
+<path>:<lineno>: ×: new-style ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errors.withMessage (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *errors.withMessage
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/pkg/errors/*errors.withMessage (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5226,21 +5730,51 @@ Error types: (1) *errors.withStack (2) *withstack.withStack (3) *errutil.leafErr
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errors.withStack (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-<path>:<lineno>: *errors.withStack (2)
+<path>:<lineno>: *errors.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/pkg/errors/*errors.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(2) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*errors.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -5268,7 +5802,7 @@ Title: "*errors.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5413,25 +5947,48 @@ Error types: (1) *safedetails.withSafeDetails (2) *withstack.withStack (3) *erru
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) safe ×
+  | ×
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *safedetails.withSafeDetails (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*safedetails.withSafeDetails: safe × (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-safe ×
-   ×
+*safedetails.withSafeDetails: safe ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/safedetails/*safedetails.withSafeDetails (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5577,24 +6134,49 @@ Error types: (1) *fmttests.werrSafeFormat (2) *withstack.withStack (3) *errutil.
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: safe ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: safe ×: new-style ×
+(1) safe ×
+  | ×
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrSafeFormat (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrSafeFormat
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: safe ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: safe ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5625,7 +6207,6 @@ newf innerone innertwo
 secondary outerthree outerfour
 
 require (?s)
-----
 ----
 &secondary.withSecondaryError{
     cause: &withstack.withStack{
@@ -5804,52 +6385,77 @@ Error types: (1) *secondary.withSecondaryError (2) *withstack.withStack (3) *err
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) secondary error attachment
+  | outerthree
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) outerthree
+  |   | outerfour
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *secondary.withSecondaryError (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  outerthree
-   outerfour
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5874,8 +6480,6 @@ Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 newf innerone innertwo
@@ -6002,21 +6606,51 @@ Error types: (1) *withstack.withStack (2) *withstack.withStack (3) *errutil.leaf
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *withstack.withStack (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-<path>:<lineno>: *withstack.withStack (2)
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(2) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -6044,7 +6678,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6243,25 +6877,47 @@ Error types: (1) *contexttags.withContext (2) *withstack.withStack (3) *errutil.
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) tags: [k×,safe=456]
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *contexttags.withContext (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*contexttags.withContext: k× (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-k×
-safe=456
+*contexttags.withContext: k×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/contexttags/*contexttags.withContext (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6406,26 +7062,48 @@ Error types: (1) *telemetrykeys.withTelemetry (2) *withstack.withStack (3) *erru
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) keys: [somekey outerthree
+  | outerfour]
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *telemetrykeys.withTelemetry (2) *withstack.withStack (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*telemetrykeys.withTelemetry: somekey (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-somekey
-outerthree
-   outerfour
+*telemetrykeys.withTelemetry: somekey
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6587,28 +7265,56 @@ Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *withstack.wit
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-stylew ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: new-stylew ×: new-style ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) new-stylew ×
+  | ×
+Wraps: (3) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (4) new-style ×
+  | ×
+Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *withstack.withStack (4) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*errutil.withPrefix: new-stylew × (2)
-<path>:<lineno>: *withstack.withStack (3)
+*errutil.withPrefix: new-stylew ×
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-new-stylew ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(3) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -6636,7 +7342,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-stylew ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-stylew ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6667,7 +7373,6 @@ newf innerone innertwo
 wrapf-attached outerthree outerfour
 
 require (?s)outerthree.*outerfour.*
-----
 ----
 &withstack.withStack{
     cause: &secondary.withSecondaryError{
@@ -6871,51 +7576,80 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-style ×
-× (payload): new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: new-style ×: new-style ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) secondary error attachment
+  | payload
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | × (payload)
+Wraps: (4) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (5) new-style ×
+  | ×
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.withPrefix (4) *withstack.withStack (5) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*errutil.withPrefix: new-style × (2)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (3)
-<path>:<lineno>: *withstack.withStack (4)
+*errutil.withPrefix: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-new-style ×
-   × (payload)
-== Extra "3: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -6923,7 +7657,7 @@ github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(4) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -6951,7 +7685,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n× (payload): new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6976,5 +7710,3 @@ Title: "*errutil.leafError: new-style ×\n× (payload): new-style ×\n×\nvia *w
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----

--- a/fmttests/testdata/format/wrap-newf-via-network
+++ b/fmttests/testdata/format/wrap-newf-via-network
@@ -5,7 +5,6 @@ opaque
 
 require (?s)innerone.*innertwo
 ----
-----
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &barriers.barrierError{
@@ -225,82 +224,84 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *ba
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) ×
+  | ×
+  | -- cause hidden behind barrier
+  | new-style ×
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) new-style ×
+  |   | ×
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  new-style ×
-   ×
-masked error: new-style ×
-   (1)
-     | (opaque error wrapper)
-     | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
-     | reportable 0:
-     |
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Wraps: (2) new-style ×
-     | ×
-   Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -325,8 +326,6 @@ Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 newf innerone innertwo
@@ -334,7 +333,6 @@ assertwrap outerthree outerfour
 opaque
 
 require (?s)outerthree.*outerfour.*innerone.*innertwo
-----
 ----
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
@@ -566,81 +564,81 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *er
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×
-×: ×
-×
---
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-*errutil.withPrefix: assertmsg: × (2)
+<path>:<lineno>: assertmsg: ×: ×
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg: ×
+  | ×
+Wraps: (4) ×
+  | ×
+  | -- cause hidden behind barrier
+  | new-style ×
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) new-style ×
+  |   | ×
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  new-style ×
-   ×
-masked error: new-style ×
-   (1)
-     | (opaque error wrapper)
-     | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
-     | reportable 0:
-     |
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Wraps: (2) new-style ×
-     | ×
-   Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-== Extra "2: details"
-assertmsg: ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -648,7 +646,7 @@ github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -673,8 +671,6 @@ Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withSt
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 newf innerone innertwo
@@ -682,7 +678,6 @@ barrier outerthree outerfour
 opaque
 
 require (?s)innerone.*innertwo
-----
 ----
 &barriers.barrierError{
     msg:       "new-style innerone\ninnertwo",
@@ -821,81 +816,51 @@ Error types: (1) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  new-style ×
-   ×
-masked error: new-style ×
-   (1)
-     | (opaque error wrapper)
-     | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
-     | reportable 0:
-     |
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Wraps: (2) new-style ×
-     | ×
-   Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+(1) ×
+  | ×
+  | -- cause hidden behind barrier
+  | new-style ×
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) new-style ×
+  |   | ×
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Error types: (1) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 newf innerone innertwo
@@ -1054,24 +1019,55 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: ×: new-style ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrDelegate
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1249,22 +1245,52 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrDelegateEmpty
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1442,22 +1468,52 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrDelegateNoPrefix
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1621,22 +1677,51 @@ Error types: (1) *hintdetail.withDetail (2) *errbase.opaqueWrapper (3) *errutil.
 =====
 == Message payload
 <path>:<lineno>: new-style ×
+(1) ×
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *hintdetail.withDetail (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *hintdetail.withDetail
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withDetail (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1798,24 +1883,50 @@ Error types: (1) *domains.withDomain (2) *errbase.opaqueWrapper (3) *errutil.lea
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) mydomain
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *domains.withDomain (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*domains.withDomain: mydomain (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-mydomain
+*domains.withDomain: mydomain
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::mydomain)
 == Exception 1 (Module: "mydomain")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1979,22 +2090,51 @@ Error types: (1) *fmttests.werrWithElidedCause (2) *errbase.opaqueWrapper (3) *e
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fmttests.werrWithElidedCause (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrWithElidedCause
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrWithElidedCause (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2172,22 +2312,52 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrEmpty
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2370,24 +2540,55 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: ×: new-style ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrFmt
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2573,24 +2774,55 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: ×: new-style ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrFmto
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2776,24 +3008,55 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: ×: new-style ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrFmtoDelegate
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2976,24 +3239,55 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: ×: new-style ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrFmtp
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3179,24 +3473,55 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: ×: new-style ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: fmt/*fmt.wrapError
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmt.wrapError
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 fmt/*fmt.wrapError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3228,7 +3553,6 @@ handled-domain outerthree outerfour
 opaque
 
 require (?s)innerone.*innertwo
-----
 ----
 &domains.withDomain{
     cause: &barriers.barrierError{
@@ -3375,85 +3699,54 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-*domains.withDomain: error domain: pkg <path> (2)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  new-style ×
-   ×
-masked error: new-style ×
-   (1)
-     | (opaque error wrapper)
-     | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
-     | reportable 0:
-     |
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Wraps: (2) new-style ×
-     | ×
-   Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-== Extra "2: details"
-error domain: pkg <path>
+(1) error domain: pkg <path>
+Wraps: (2) ×
+  | ×
+  | -- cause hidden behind barrier
+  | new-style ×
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) new-style ×
+  |   | ×
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Error types: (1) *domains.withDomain (2) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*domains.withDomain: error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 newf innerone innertwo
@@ -3593,22 +3886,51 @@ Error types: (1) *hintdetail.withHint (2) *errbase.opaqueWrapper (3) *errutil.le
 =====
 == Message payload
 <path>:<lineno>: new-style ×
+(1) ×
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *hintdetail.withHint (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *hintdetail.withHint
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withHint (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3774,26 +4096,52 @@ Error types: (1) *issuelink.withIssueLink (2) *errbase.opaqueWrapper (3) *erruti
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) issue: https://mysite
+  | detail: outerthree
+  | outerfour
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *issuelink.withIssueLink (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*issuelink.withIssueLink: https://mysite (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-https://mysite
-outerthree
-   outerfour
+*issuelink.withIssueLink: https://mysite
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/issuelink/*issuelink.withIssueLink (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3971,22 +4319,52 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrMigrated
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated (some/previous/path/prevpkg.prevType::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4151,27 +4529,52 @@ Error types: (1) *errutil.withPrefix (2) *errbase.opaqueWrapper (3) *errutil.lea
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: outerthree
-outerfour: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: outerthree: new-style ×
+(1) outerthree
+  | outerfour
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errutil.withPrefix (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*errutil.withPrefix: outerthree (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-outerthree
-   outerfour
+*errutil.withPrefix: outerthree
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: outerthree\nouterfour: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: outerthree: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4203,7 +4606,6 @@ newfw outerthree outerfour
 opaque
 
 require (?s)outerthree.*outerfour.*innerone.*innertwo
-----
 ----
 &errbase.opaqueWrapper{
     cause: &secondary.withSecondaryError{
@@ -4508,52 +4910,111 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 =====
 == Message payload
 <path>:<lineno>: new-style (×
-×) :: new-style ×
-× ::
---
-*errutil.leafError: new-style × (1)
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | new-style ×
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) new-style ×
+  |   | ×
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (3) new-style (×
+  | ×) :: new-style ×
+  | × ::
+Wraps: (4)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (5) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.withNewMessage (4) *errbase.opaqueWrapper (5) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*errutil.withNewMessage: new-style (× (2)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (3)
-<path>:<lineno>: *withstack.withStack (4)
+*errutil.withNewMessage: new-style (×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-new-style (×
-   ×) :: new-style ×
-   × ::
-== Extra "3: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -4561,7 +5022,7 @@ github.com/cockroachdb/errors/errutil/*errutil.withNewMessage (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(4) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -4589,7 +5050,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style (×\n×) :: new-style ×\n× ::\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style (×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4614,8 +5075,6 @@ Title: "*errutil.leafError: new-style (×\n×) :: new-style ×\n× ::\nvia *with
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 newf innerone innertwo
@@ -4777,24 +5236,55 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: ×: new-style ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrNoFmt
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4973,22 +5463,50 @@ Error types: (1) *os.LinkError (2) *errbase.opaqueWrapper (3) *errutil.leafError
 =====
 == Message payload
 <path>:<lineno>: link × ×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) link × ×
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *os.LinkError (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *os.LinkError
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 os/*os.LinkError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: link × ×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: link × ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5171,22 +5689,53 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 =====
 == Message payload
 <path>:<lineno>: ×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) ×
+  |
+  | (opaque error wrapper)
+  | type name: net/*net.OpError
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *net.OpError
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 net/*net.OpError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5363,22 +5912,50 @@ Error types: (1) *fs.PathError (2) *errbase.opaqueWrapper (3) *errutil.leafError
 =====
 == Message payload
 <path>:<lineno>: link ×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) link ×
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *fs.PathError (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fs.PathError
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 io/fs/*fs.PathError (os/*os.PathError::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: link ×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: link ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5553,22 +6130,50 @@ Error types: (1) *os.SyscallError (2) *errbase.opaqueWrapper (3) *errutil.leafEr
 =====
 == Message payload
 <path>:<lineno>: open: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) open
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *os.SyscallError (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *os.SyscallError
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 os/*os.SyscallError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: open: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: open: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5781,24 +6386,52 @@ Error types: (1) *errors.withMessage (2) *errbase.opaqueWrapper (3) *errutil.lea
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
+<path>:<lineno>: ×: new-style ×
+(1) ××
 ×
---
-*errutil.leafError: new-style × (1)
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errors.withMessage (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *errors.withMessage
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/pkg/errors/*errors.withMessage (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6033,21 +6666,78 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/pkg/errors/*errors.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-<path>:<lineno>: *errors.withStack (2)
+<path>:<lineno>: *errors.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/pkg/errors/*errors.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(2) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*errors.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -6075,7 +6765,7 @@ Title: "*errors.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6239,25 +6929,51 @@ Error types: (1) *safedetails.withSafeDetails (2) *errbase.opaqueWrapper (3) *er
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) safe ×
+  | ×
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *safedetails.withSafeDetails (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*safedetails.withSafeDetails: safe × (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-safe ×
-   ×
+*safedetails.withSafeDetails: safe ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/safedetails/*safedetails.withSafeDetails (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6440,24 +7156,55 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: ×: new-style ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *fmttests.werrSafeFormat
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6489,7 +7236,6 @@ secondary outerthree outerfour
 opaque
 
 require (?s)innerone.*innertwo
-----
 ----
 &secondary.withSecondaryError{
     cause: &errbase.opaqueWrapper{
@@ -6704,52 +7450,83 @@ Error types: (1) *secondary.withSecondaryError (2) *errbase.opaqueWrapper (3) *e
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) secondary error attachment
+  | outerthree
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) outerthree
+  |   | outerfour
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *secondary.withSecondaryError (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  outerthree
-   outerfour
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6774,8 +7551,6 @@ Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 newf innerone innertwo
@@ -6981,21 +7756,78 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-<path>:<lineno>: *withstack.withStack (2)
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(2) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -7023,7 +7855,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -7233,25 +8065,50 @@ Error types: (1) *contexttags.withContext (2) *errbase.opaqueWrapper (3) *erruti
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) tags: [k×,safe=×]
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *contexttags.withContext (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*contexttags.withContext: k× (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-k×
-safe=456
+*contexttags.withContext: k×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/contexttags/*contexttags.withContext (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -7415,26 +8272,51 @@ Error types: (1) *telemetrykeys.withTelemetry (2) *errbase.opaqueWrapper (3) *er
 =====
 == Message payload
 <path>:<lineno>: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+(1) keys: [somekey outerthree
+  | outerfour]
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) new-style ×
+  | ×
+Error types: (1) *telemetrykeys.withTelemetry (2) *errbase.opaqueWrapper (3) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*telemetrykeys.withTelemetry: somekey (2)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-somekey
-outerthree
-   outerfour
+*telemetrykeys.withTelemetry: somekey
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -7675,28 +8557,83 @@ Error types: (1) *errbase.opaqueWrapper (2) *errutil.withPrefix (3) *errbase.opa
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-stylew ×
-×: new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: new-stylew ×: new-style ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) new-stylew ×
+  | ×
+Wraps: (3)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (4) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *errutil.withPrefix (3) *errbase.opaqueWrapper (4) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*errutil.withPrefix: new-stylew × (2)
-<path>:<lineno>: *withstack.withStack (3)
+*errutil.withPrefix: new-stylew ×
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-new-stylew ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(3) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -7724,7 +8661,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-stylew ×\n×: new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-stylew ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -7756,7 +8693,6 @@ wrapf-attached outerthree outerfour
 opaque
 
 require (?s)outerthree.*outerfour.*innerone.*innertwo
-----
 ----
 &errbase.opaqueWrapper{
     cause: &secondary.withSecondaryError{
@@ -8056,51 +8992,110 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-style ×
-× (payload): new-style ×
-×
---
-*errutil.leafError: new-style × (1)
+<path>:<lineno>: new-style ×: new-style ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | payload
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | × (payload)
+Wraps: (4)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (5) new-style ×
+  | ×
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.withPrefix (4) *errbase.opaqueWrapper (5) *errutil.leafError
+-- report composition:
+*errutil.leafError: new-style ×
 <path>:<lineno>: *withstack.withStack (top exception)
-*errutil.withPrefix: new-style × (2)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (3)
-<path>:<lineno>: *withstack.withStack (4)
+*errutil.withPrefix: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   ×
-== Extra "2: details"
-new-style ×
-   × (payload)
-== Extra "3: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -8108,7 +9103,7 @@ github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(4) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -8136,7 +9131,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errutil.leafError: new-style ×\n× (payload): new-style ×\n×\nvia *withstack.withStack"
+Title: "*errutil.leafError: new-style ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -8161,5 +9156,3 @@ Title: "*errutil.leafError: new-style ×\n× (payload): new-style ×\n×\nvia *w
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----

--- a/fmttests/testdata/format/wrap-newf-via-network
+++ b/fmttests/testdata/format/wrap-newf-via-network
@@ -7,8 +7,8 @@ require (?s)innerone.*innertwo
 ----
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
-        cause: &barriers.barrierError{
-            msg:       "new-style innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "new-style ‹innerone›\n‹innertwo›",
             maskedErr: &errbase.opaqueWrapper{
                 cause:   &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
                 prefix:  "",
@@ -35,8 +35,8 @@ require (?s)innerone.*innertwo
 == %#v
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
-        cause: &barriers.barrierError{
-            msg:       "new-style innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "new-style ‹innerone›\n‹innertwo›",
             maskedErr: &errbase.opaqueWrapper{
                 cause:   &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
                 prefix:  "",
@@ -133,7 +133,7 @@ Wraps: (3) new-style innerone
   | Wraps: (2) new-style innerone
   |   | innertwo
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -143,7 +143,7 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *ba
 ===== redactable formats
 =====
 == printed via redact Print(), ok - congruent with %v
-‹new-style innerone›
+new-style ‹innerone›
 ‹innertwo›
 == printed via redact Printf() %v = Print(), good
 == printed via redact Printf() %s = Print(), good
@@ -151,7 +151,7 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *ba
 == printed via redact Printf() %x, refused - good
 == printed via redact Printf() %X, refused - good
 == printed via redact Printf() %+v, ok - congruent with %+v
-‹new-style innerone›
+new-style ‹innerone›
 (1) assertion failure
 Wraps: (2)
   | (opaque error wrapper)
@@ -182,7 +182,7 @@ Wraps: (2)
   | <tab><path>:<lineno>
   | runtime.goexit
   | <tab><path>:<lineno>
-Wraps: (3) ‹new-style innerone›
+Wraps: (3) new-style ‹innerone›
   | ‹innertwo›
   | -- cause hidden behind barrier
   | new-style ‹innerone›
@@ -218,12 +218,12 @@ Wraps: (3) ‹new-style innerone›
   | Wraps: (2) new-style ‹innerone›
   |   | ‹innertwo›
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
+<path>:<lineno>: new-style ×
 (1) assertion failure
 Wraps: (2)
   | (opaque error wrapper)
@@ -254,7 +254,7 @@ Wraps: (2)
   | <tab><path>:<lineno>
   | runtime.goexit
   | <tab><path>:<lineno>
-Wraps: (3) ×
+Wraps: (3) new-style ×
   | ×
   | -- cause hidden behind barrier
   | new-style ×
@@ -290,18 +290,18 @@ Wraps: (3) ×
   | Wraps: (2) new-style ×
   |   | ×
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*barriers.barrierErr: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -337,8 +337,8 @@ require (?s)outerthree.*outerfour.*innerone.*innertwo
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "new-style innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "new-style ‹innerone›\n‹innertwo›",
                 maskedErr: &errbase.opaqueWrapper{
                     cause:   &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
                     prefix:  "",
@@ -368,8 +368,8 @@ require (?s)outerthree.*outerfour.*innerone.*innertwo
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "new-style innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "new-style ‹innerone›\n‹innertwo›",
                 maskedErr: &errbase.opaqueWrapper{
                     cause:   &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
                     prefix:  "",
@@ -471,7 +471,7 @@ Wraps: (4) new-style innerone
   | Wraps: (2) new-style innerone
   |   | innertwo
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -482,7 +482,7 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *er
 =====
 == printed via redact Print(), ok - congruent with %v
 assertmsg: ‹outerthree›
-‹outerfour›: ‹new-style innerone›
+‹outerfour›: new-style ‹innerone›
 ‹innertwo›
 == printed via redact Printf() %v = Print(), good
 == printed via redact Printf() %s = Print(), good
@@ -490,7 +490,7 @@ assertmsg: ‹outerthree›
 == printed via redact Printf() %x, refused - good
 == printed via redact Printf() %X, refused - good
 == printed via redact Printf() %+v, ok - congruent with %+v
-assertmsg: ‹outerthree›: ‹new-style innerone›
+assertmsg: ‹outerthree›: new-style ‹innerone›
 (1) assertion failure
 Wraps: (2)
   | (opaque error wrapper)
@@ -523,7 +523,7 @@ Wraps: (2)
   | <tab><path>:<lineno>
 Wraps: (3) assertmsg: ‹outerthree›
   | ‹outerfour›
-Wraps: (4) ‹new-style innerone›
+Wraps: (4) new-style ‹innerone›
   | ‹innertwo›
   | -- cause hidden behind barrier
   | new-style ‹innerone›
@@ -559,12 +559,12 @@ Wraps: (4) ‹new-style innerone›
   | Wraps: (2) new-style ‹innerone›
   |   | ‹innertwo›
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×: ×
+<path>:<lineno>: assertmsg: ×: new-style ×
 (1) assertion failure
 Wraps: (2)
   | (opaque error wrapper)
@@ -597,7 +597,7 @@ Wraps: (2)
   | <tab><path>:<lineno>
 Wraps: (3) assertmsg: ×
   | ×
-Wraps: (4) ×
+Wraps: (4) new-style ×
   | ×
   | -- cause hidden behind barrier
   | new-style ×
@@ -633,20 +633,20 @@ Wraps: (4) ×
   | Wraps: (2) new-style ×
   |   | ×
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*barriers.barrierErr: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 *errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: assertmsg: ×: new-style ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -679,8 +679,8 @@ opaque
 
 require (?s)innerone.*innertwo
 ----
-&barriers.barrierError{
-    msg:       "new-style innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "new-style ‹innerone›\n‹innertwo›",
     maskedErr: &errbase.opaqueWrapper{
         cause:   &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
         prefix:  "",
@@ -696,8 +696,8 @@ require (?s)innerone.*innertwo
 ===== non-redactable formats
 =====
 == %#v
-&barriers.barrierError{
-    msg:       "new-style innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "new-style ‹innerone›\n‹innertwo›",
     maskedErr: &errbase.opaqueWrapper{
         cause:   &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
         prefix:  "",
@@ -755,7 +755,7 @@ new-style innerone
   | Wraps: (2) new-style innerone
   |   | innertwo
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -765,7 +765,7 @@ Error types: (1) *barriers.barrierError
 ===== redactable formats
 =====
 == printed via redact Print(), ok - congruent with %v
-‹new-style innerone›
+new-style ‹innerone›
 ‹innertwo›
 == printed via redact Printf() %v = Print(), good
 == printed via redact Printf() %s = Print(), good
@@ -773,8 +773,8 @@ Error types: (1) *barriers.barrierError
 == printed via redact Printf() %x, refused - good
 == printed via redact Printf() %X, refused - good
 == printed via redact Printf() %+v, ok - congruent with %+v
-‹new-style innerone›
-(1) ‹new-style innerone›
+new-style ‹innerone›
+(1) new-style ‹innerone›
   | ‹innertwo›
   | -- cause hidden behind barrier
   | new-style ‹innerone›
@@ -810,13 +810,13 @@ Error types: (1) *barriers.barrierError
   | Wraps: (2) new-style ‹innerone›
   |   | ‹innertwo›
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
 == Message payload
-×
-(1) ×
+new-style ×
+(1) new-style ×
   | ×
   | -- cause hidden behind barrier
   | new-style ×
@@ -852,14 +852,14 @@ Error types: (1) *barriers.barrierError
   | Wraps: (2) new-style ×
   |   | ×
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*barriers.barrierErr: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "*barriers.barrierError"
-Title: "×"
+Type: "*barriers.barrierErr"
+Title: "new-style ×"
 (NO STACKTRACE)
 
 run
@@ -3555,8 +3555,8 @@ opaque
 require (?s)innerone.*innertwo
 ----
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "new-style innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "new-style ‹innerone›\n‹innertwo›",
         maskedErr: &errbase.opaqueWrapper{
             cause:   &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
             prefix:  "",
@@ -3575,8 +3575,8 @@ require (?s)innerone.*innertwo
 =====
 == %#v
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "new-style innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "new-style ‹innerone›\n‹innertwo›",
         maskedErr: &errbase.opaqueWrapper{
             cause:   &errutil.leafError{msg:"new-style ‹innerone›\n‹innertwo›"},
             prefix:  "",
@@ -3637,7 +3637,7 @@ Wraps: (2) new-style innerone
   | Wraps: (2) new-style innerone
   |   | innertwo
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -3647,7 +3647,7 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 ===== redactable formats
 =====
 == printed via redact Print(), ok - congruent with %v
-‹new-style innerone›
+new-style ‹innerone›
 ‹innertwo›
 == printed via redact Printf() %v = Print(), good
 == printed via redact Printf() %s = Print(), good
@@ -3655,9 +3655,9 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 == printed via redact Printf() %x, refused - good
 == printed via redact Printf() %X, refused - good
 == printed via redact Printf() %+v, ok - congruent with %+v
-‹new-style innerone›
+new-style ‹innerone›
 (1) error domain: pkg <path>
-Wraps: (2) ‹new-style innerone›
+Wraps: (2) new-style ‹innerone›
   | ‹innertwo›
   | -- cause hidden behind barrier
   | new-style ‹innerone›
@@ -3693,14 +3693,14 @@ Wraps: (2) ‹new-style innerone›
   | Wraps: (2) new-style ‹innerone›
   |   | ‹innertwo›
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
 == Message payload
-×
+new-style ×
 (1) error domain: pkg <path>
-Wraps: (2) ×
+Wraps: (2) new-style ×
   | ×
   | -- cause hidden behind barrier
   | new-style ×
@@ -3736,16 +3736,16 @@ Wraps: (2) ×
   | Wraps: (2) new-style ×
   |   | ×
   | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+*barriers.barrierErr: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 *domains.withDomain: error domain: pkg <path>
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
-Type: "*barriers.barrierError"
-Title: "×"
+Type: "*barriers.barrierErr"
+Title: "new-style ×"
 (NO STACKTRACE)
 
 run

--- a/fmttests/testdata/format/wrap-newf-via-network
+++ b/fmttests/testdata/format/wrap-newf-via-network
@@ -261,6 +261,39 @@ details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
   new-style ×
    ×
+masked error: new-style ×
+   (1)
+     | (opaque error wrapper)
+     | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+     | reportable 0:
+     |
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Wraps: (2) new-style ×
+     | ×
+   Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -572,6 +605,39 @@ details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
   new-style ×
    ×
+masked error: new-style ×
+   (1)
+     | (opaque error wrapper)
+     | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+     | reportable 0:
+     |
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Wraps: (2) new-style ×
+     | ×
+   Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
 == Extra "2: details"
 assertmsg: ×
    ×
@@ -789,6 +855,39 @@ details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
   new-style ×
    ×
+masked error: new-style ×
+   (1)
+     | (opaque error wrapper)
+     | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+     | reportable 0:
+     |
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Wraps: (2) new-style ×
+     | ×
+   Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
@@ -3311,6 +3410,39 @@ details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
   new-style ×
    ×
+masked error: new-style ×
+   (1)
+     | (opaque error wrapper)
+     | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+     | reportable 0:
+     |
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Wraps: (2) new-style ×
+     | ×
+   Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
 == Extra "2: details"
 error domain: pkg <path>
 == Extra "error types"

--- a/fmttests/testdata/format/wrap-nofmt
+++ b/fmttests/testdata/format/wrap-nofmt
@@ -6,8 +6,8 @@ require (?s)
 ----
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
         },
         stack: &stack{...},
@@ -19,8 +19,8 @@ require (?s)
 == %#v
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
         },
         stack: &stack{...},
@@ -70,7 +70,7 @@ Wraps: (3) innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -123,7 +123,7 @@ Wraps: (3) ‹innerone›
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -163,18 +163,18 @@ Wraps: (3) ×
   | (1) ××
   | ×
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -209,8 +209,8 @@ require (?s)outerthree.*outerfour.*
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
             },
             prefix: "assertmsg: ‹outerthree›\n‹outerfour›",
@@ -225,8 +225,8 @@ require (?s)outerthree.*outerfour.*
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
             },
             prefix: "assertmsg: ‹outerthree›\n‹outerfour›",
@@ -281,7 +281,7 @@ Wraps: (4) innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -337,7 +337,7 @@ Wraps: (4) ‹innerone›
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -379,20 +379,20 @@ Wraps: (4) ×
   | (1) ××
   | ×
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -424,16 +424,16 @@ barrier outerthree outerfour
 
 require (?s)
 ----
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
 }
 =====
 ===== non-redactable formats
 =====
 == %#v
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
 }
 == Error()
@@ -453,7 +453,7 @@ innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -479,7 +479,7 @@ Error types: (1) *barriers.barrierError
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -492,13 +492,13 @@ Error types: (1) *barriers.barrierError
   | (1) ××
   | ×
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 
@@ -1464,8 +1464,8 @@ handled-domain outerthree outerfour
 require (?s)
 ----
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
     },
     domain: "error domain: pkg <path>",
@@ -1475,8 +1475,8 @@ require (?s)
 =====
 == %#v
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
     },
     domain: "error domain: pkg <path>",
@@ -1499,7 +1499,7 @@ Wraps: (2) innerone
   | (1) innerone
   |   | innertwo
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -1526,7 +1526,7 @@ Wraps: (2) ‹innerone›
   | (1) ‹innerone›‹›
   | ‹  | innertwo›
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -1540,15 +1540,15 @@ Wraps: (2) ×
   | (1) ××
   | ×
   | Error types: (1) *fmttests.errNoFmt
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *domains.withDomain: error domain: pkg <path>
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 

--- a/fmttests/testdata/format/wrap-nofmt
+++ b/fmttests/testdata/format/wrap-nofmt
@@ -129,24 +129,52 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barr
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
-*barriers.barrierError: masked error: × (1)
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *fmttests.errNoFmt
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *fmttests.errNoFmt
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -314,23 +342,49 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *erru
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×
-×: ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*errutil.withPrefix: assertmsg: × (2)
+<path>:<lineno>: assertmsg: ×: ×
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg: ×
+  | ×
+Wraps: (4) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *fmttests.errNoFmt
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *fmttests.errNoFmt
-== Extra "2: details"
-assertmsg: ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -338,7 +392,7 @@ github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -431,20 +485,21 @@ Error types: (1) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *fmttests.errNoFmt
+(1) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *fmttests.errNoFmt
+Error types: (1) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -513,10 +568,15 @@ Error types: (1) *fmttests.werrDelegate (2) *fmttests.errNoFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+×
+×
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrDelegate (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrDelegate
 == Extra "error types"
@@ -524,7 +584,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -584,8 +644,11 @@ Error types: (1) *fmttests.werrDelegateEmpty (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1)
+Wraps: (2) ××
 ×
---
+Error types: (1) *fmttests.werrDelegateEmpty (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrDelegateEmpty
 == Extra "error types"
@@ -593,7 +656,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -653,8 +716,11 @@ Error types: (1) *fmttests.werrDelegateNoPrefix (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *fmttests.werrDelegateNoPrefix (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrDelegateNoPrefix
 == Extra "error types"
@@ -662,7 +728,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -726,8 +792,12 @@ Error types: (1) *hintdetail.withDetail (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *hintdetail.withDetail (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *hintdetail.withDetail
 == Extra "error types"
@@ -735,7 +805,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withDetail (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -797,19 +867,19 @@ Error types: (1) *domains.withDomain (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) mydomain
+Wraps: (2) ××
 ×
---
+Error types: (1) *domains.withDomain (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
-*domains.withDomain: mydomain (1)
-(check the extra data payloads)
-== Extra "1: details"
-mydomain
+*domains.withDomain: mydomain
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::mydomain)
 == Exception 1 (Module: "mydomain")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -873,8 +943,12 @@ Error types: (1) *fmttests.werrWithElidedCause (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrWithElidedCause (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrWithElidedCause
 == Extra "error types"
@@ -882,7 +956,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrWithElidedCause (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -942,8 +1016,11 @@ Error types: (1) *fmttests.werrEmpty (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1)
+Wraps: (2) ××
 ×
---
+Error types: (1) *fmttests.werrEmpty (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrEmpty
 == Extra "error types"
@@ -951,7 +1028,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1022,10 +1099,16 @@ Error types: (1) *fmttests.werrFmt (2) *fmttests.errNoFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+×
+×
+×
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrFmt (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrFmt
 == Extra "error types"
@@ -1033,7 +1116,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1107,10 +1190,13 @@ Error types: (1) *fmttests.werrFmto (2) *fmttests.errNoFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrFmto (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrFmto
 == Extra "error types"
@@ -1118,7 +1204,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1192,10 +1278,13 @@ Error types: (1) *fmttests.werrFmtoDelegate (2) *fmttests.errNoFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrFmtoDelegate (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrFmtoDelegate
 == Extra "error types"
@@ -1203,7 +1292,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1268,10 +1357,13 @@ Error types: (1) *fmttests.werrFmtp (2) *fmttests.errNoFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrFmtp (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrFmtp
 == Extra "error types"
@@ -1279,7 +1371,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1348,10 +1440,13 @@ Error types: (1) *fmt.wrapError (2) *fmttests.errNoFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmt.wrapError (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmt.wrapError
 == Extra "error types"
@@ -1359,7 +1454,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 fmt/*fmt.wrapError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1437,24 +1532,24 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*domains.withDomain: error domain: pkg <path> (2)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ××
-   ×
-   Error types: (1) *fmttests.errNoFmt
-== Extra "2: details"
-error domain: pkg <path>
+(1) error domain: pkg <path>
+Wraps: (2) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *fmttests.errNoFmt
+Error types: (1) *domains.withDomain (2) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*domains.withDomain: error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1518,8 +1613,12 @@ Error types: (1) *hintdetail.withHint (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *hintdetail.withHint (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *hintdetail.withHint
 == Extra "error types"
@@ -1527,7 +1626,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withHint (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1593,21 +1692,21 @@ Error types: (1) *issuelink.withIssueLink (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) issue: https://mysite
+  | detail: outerthree
+  | outerfour
+Wraps: (2) ××
 ×
---
+Error types: (1) *issuelink.withIssueLink (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
-*issuelink.withIssueLink: https://mysite (1)
-(check the extra data payloads)
-== Extra "1: details"
-https://mysite
-outerthree
-   outerfour
+*issuelink.withIssueLink: https://mysite
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/issuelink/*issuelink.withIssueLink (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1667,8 +1766,11 @@ Error types: (1) *fmttests.werrMigrated (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1)
+Wraps: (2) ××
 ×
---
+Error types: (1) *fmttests.werrMigrated (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrMigrated
 == Extra "error types"
@@ -1676,7 +1778,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated (some/previous/path/prevpkg.prevType::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1741,22 +1843,21 @@ Error types: (1) *errutil.withPrefix (2) *fmttests.errNoFmt
 ===== Sentry reporting
 =====
 == Message payload
-outerthree
-outerfour: ×
+outerthree: ×
+(1) outerthree
+  | outerfour
+Wraps: (2) ××
 ×
---
+Error types: (1) *errutil.withPrefix (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
-*errutil.withPrefix: outerthree (1)
-(check the extra data payloads)
-== Extra "1: details"
-outerthree
-   outerfour
+*errutil.withPrefix: outerthree
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "outerthree\nouterfour: ×\n×"
+Title: "outerthree: ×"
 (NO STACKTRACE)
 
 run
@@ -1898,18 +1999,48 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 =====
 == Message payload
 <path>:<lineno>: new-style (×
-×) :: ×
-× ::
---
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | ×
+  | (1) ××
+  | ×
+  | Error types: (1) *fmttests.errNoFmt
+Wraps: (3) new-style (×
+  | ×) :: ×
+  | × ::
+Wraps: (4) ××
+×
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.withNewMessage (4) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
-*errutil.withNewMessage: new-style (× (1)
+*errutil.withNewMessage: new-style (×
 *secondary.withSecondaryError
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style (×
-   ×) :: ×
-   × ::
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withNewMessage (*::)
@@ -1917,7 +2048,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errNoFmt: new-style (×\n×) :: ×\n× ::\nvia *withstack.withStack"
+Title: "*fmttests.errNoFmt: new-style (×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2009,10 +2140,13 @@ Error types: (1) *fmttests.werrNoFmt (2) *fmttests.errNoFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *fmttests.werrNoFmt (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrNoFmt
 == Extra "error types"
@@ -2020,7 +2154,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2090,8 +2224,11 @@ Error types: (1) *os.LinkError (2) *fmttests.errNoFmt
 =====
 == Message payload
 link × ×: ×
+(1) link × ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *os.LinkError (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *os.LinkError
 == Extra "error types"
@@ -2099,7 +2236,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 os/*os.LinkError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "link × ×: ×\n×"
+Title: "link × ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2171,8 +2308,11 @@ Error types: (1) *net.OpError (2) *fmttests.errNoFmt
 =====
 == Message payload
 send tcp ×: ×
+(1) send tcp ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *net.OpError (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *net.OpError
 == Extra "error types"
@@ -2180,7 +2320,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 net/*net.OpError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "send tcp ×: ×\n×"
+Title: "send tcp ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2248,8 +2388,11 @@ Error types: (1) *fs.PathError (2) *fmttests.errNoFmt
 =====
 == Message payload
 link ×: ×
+(1) link ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *fs.PathError (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fs.PathError
 == Extra "error types"
@@ -2257,7 +2400,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 io/fs/*fs.PathError (os/*os.PathError::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "link ×: ×\n×"
+Title: "link ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2323,8 +2466,11 @@ Error types: (1) *os.SyscallError (2) *fmttests.errNoFmt
 =====
 == Message payload
 open: ×
+(1) open
+Wraps: (2) ××
 ×
---
+Error types: (1) *os.SyscallError (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *os.SyscallError
 == Extra "error types"
@@ -2332,7 +2478,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 os/*os.SyscallError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "open: ×\n×"
+Title: "open: ×"
 (NO STACKTRACE)
 
 run
@@ -2414,10 +2560,13 @@ Error types: (1) *errors.withMessage (2) *fmttests.errNoFmt
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+Error types: (1) *errors.withMessage (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *errors.withMessage
 == Extra "error types"
@@ -2425,7 +2574,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/pkg/errors/*errors.withMessage (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2572,8 +2721,36 @@ Error types: (1) *errors.withStack (2) *fmttests.errNoFmt
 =====
 == Message payload
 <path>:<lineno>: ×
+(1)
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ××
 ×
---
+Error types: (1) *errors.withStack (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 <path>:<lineno>: *errors.withStack (top exception)
 == Extra "error types"
@@ -2581,7 +2758,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/pkg/errors/*errors.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errNoFmt: ×\n×\nvia *errors.withStack"
+Title: "*fmttests.errNoFmt: ×\nvia *errors.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2668,20 +2845,20 @@ Error types: (1) *safedetails.withSafeDetails (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) safe ×
+  | ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *safedetails.withSafeDetails (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
-*safedetails.withSafeDetails: safe × (1)
-(check the extra data payloads)
-== Extra "1: details"
-safe ×
-   ×
+*safedetails.withSafeDetails: safe ×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/safedetails/*safedetails.withSafeDetails (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2746,10 +2923,13 @@ Error types: (1) *fmttests.werrSafeFormat (2) *fmttests.errNoFmt
 ===== Sentry reporting
 =====
 == Message payload
-safe ×
-×: ×
+safe ×: ×
+(1) safe ×
+  | ×
+Wraps: (2) ××
 ×
---
+Error types: (1) *fmttests.werrSafeFormat (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrSafeFormat
 == Extra "error types"
@@ -2757,7 +2937,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "safe ×\n×: ×\n×"
+Title: "safe ×: ×"
 (NO STACKTRACE)
 
 run
@@ -2765,7 +2945,6 @@ nofmt innerone innertwo
 secondary outerthree outerfour
 
 require (?s)
-----
 ----
 &secondary.withSecondaryError{
     cause:          &fmttests.errNoFmt{msg:"innerone\ninnertwo"},
@@ -2886,50 +3065,50 @@ Error types: (1) *secondary.withSecondaryError (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) secondary error attachment
+  | outerthree
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) outerthree
+  |   | outerfour
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (2) ××
 ×
---
+Error types: (1) *secondary.withSecondaryError (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  outerthree
-   outerfour
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 nofmt innerone innertwo
@@ -3040,8 +3219,36 @@ Error types: (1) *withstack.withStack (2) *fmttests.errNoFmt
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ××
 ×
---
+Error types: (1) *withstack.withStack (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
 <path>:<lineno>: *withstack.withStack (top exception)
 == Extra "error types"
@@ -3049,7 +3256,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errNoFmt: ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errNoFmt: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3190,20 +3397,19 @@ Error types: (1) *contexttags.withContext (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) tags: [k×,safe=456]
+Wraps: (2) ××
 ×
---
+Error types: (1) *contexttags.withContext (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
-*contexttags.withContext: k× (1)
-(check the extra data payloads)
-== Extra "1: details"
-k×
-safe=456
+*contexttags.withContext: k×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/contexttags/*contexttags.withContext (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3267,21 +3473,20 @@ Error types: (1) *telemetrykeys.withTelemetry (2) *fmttests.errNoFmt
 =====
 == Message payload
 ×
+(1) keys: [somekey outerthree
+  | outerfour]
+Wraps: (2) ××
 ×
---
+Error types: (1) *telemetrykeys.withTelemetry (2) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
-*telemetrykeys.withTelemetry: somekey (1)
-(check the extra data payloads)
-== Extra "1: details"
-somekey
-outerthree
-   outerfour
+*telemetrykeys.withTelemetry: somekey
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3404,24 +3609,49 @@ Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *fmttests.errN
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-stylew ×
-×: ×
+<path>:<lineno>: new-stylew ×: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) new-stylew ×
+  | ×
+Wraps: (3) ××
 ×
---
+Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
-*errutil.withPrefix: new-stylew × (1)
+*errutil.withPrefix: new-stylew ×
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-stylew ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errNoFmt: new-stylew ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errNoFmt: new-stylew ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3452,7 +3682,6 @@ nofmt innerone innertwo
 wrapf-attached outerthree outerfour
 
 require (?s)outerthree.*outerfour.*
-----
 ----
 &withstack.withStack{
     cause: &secondary.withSecondaryError{
@@ -3640,47 +3869,73 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-style ×
-× (payload): ×
+<path>:<lineno>: new-style ×: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | payload
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | × (payload)
+Wraps: (4) ××
 ×
---
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.withPrefix (4) *fmttests.errNoFmt
+-- report composition:
 *fmttests.errNoFmt
-*errutil.withPrefix: new-style × (1)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
+*errutil.withPrefix: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   × (payload)
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -3688,7 +3943,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errNoFmt: new-style ×\n× (payload): ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errNoFmt: new-style ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3713,5 +3968,3 @@ Title: "*fmttests.errNoFmt: new-style ×\n× (payload): ×\n×\nvia *withstack.w
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----

--- a/fmttests/testdata/format/wrap-nofmt
+++ b/fmttests/testdata/format/wrap-nofmt
@@ -131,9 +131,15 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barr
 <path>:<lineno>: ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *fmttests.errNoFmt
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -312,12 +318,17 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *erru
 ×: ×
 ×
 --
-*barriers.barrierError
-*errutil.withPrefix: assertmsg: × (1)
+*barriers.barrierError: masked error: × (1)
+*errutil.withPrefix: assertmsg: × (2)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *fmttests.errNoFmt
+== Extra "2: details"
 assertmsg: ×
    ×
 == Extra "error types"
@@ -422,7 +433,13 @@ Error types: (1) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *fmttests.errNoFmt
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
@@ -1422,10 +1439,15 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
-*domains.withDomain: error domain: pkg <path> (1)
+*barriers.barrierError: masked error: × (1)
+*domains.withDomain: error domain: pkg <path> (2)
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ××
+   ×
+   Error types: (1) *fmttests.errNoFmt
+== Extra "2: details"
 error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)

--- a/fmttests/testdata/format/wrap-nofmt-via-network
+++ b/fmttests/testdata/format/wrap-nofmt-via-network
@@ -172,9 +172,18 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *ba
 <path>:<lineno>: ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+   Error types: (1) *errbase.opaqueLeaf
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -394,12 +403,20 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *er
 ×: ×
 ×
 --
-*barriers.barrierError
-*errutil.withPrefix: assertmsg: × (1)
+*barriers.barrierError: masked error: × (1)
+*errutil.withPrefix: assertmsg: × (2)
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+   Error types: (1) *errbase.opaqueLeaf
+== Extra "2: details"
 assertmsg: ×
    ×
 == Extra "error types"
@@ -527,7 +544,16 @@ Error types: (1) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
+*barriers.barrierError: masked error: × (1)
+(check the extra data payloads)
+== Extra "1: details"
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+   Error types: (1) *errbase.opaqueLeaf
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
@@ -1965,10 +1991,18 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 ×
 ×
 --
-*barriers.barrierError
-*domains.withDomain: error domain: pkg <path> (1)
+*barriers.barrierError: masked error: × (1)
+*domains.withDomain: error domain: pkg <path> (2)
 (check the extra data payloads)
 == Extra "1: details"
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+   Error types: (1) *errbase.opaqueLeaf
+== Extra "2: details"
 error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)

--- a/fmttests/testdata/format/wrap-nofmt-via-network
+++ b/fmttests/testdata/format/wrap-nofmt-via-network
@@ -7,8 +7,8 @@ require (?s)innerone.*innertwo
 ----
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errbase.opaqueLeaf{
                 msg:     "innerone\ninnertwo",
                 details: errorspb.EncodedErrorDetails{
@@ -34,8 +34,8 @@ require (?s)innerone.*innertwo
 == %#v
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errbase.opaqueLeaf{
                 msg:     "innerone\ninnertwo",
                 details: errorspb.EncodedErrorDetails{
@@ -105,7 +105,7 @@ Wraps: (3) innerone
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -164,7 +164,7 @@ Wraps: (3) ‹innerone›
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -210,18 +210,18 @@ Wraps: (3) ×
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -257,8 +257,8 @@ require (?s)outerthree.*outerfour.*innerone.*innertwo
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errbase.opaqueLeaf{
                     msg:     "innerone\ninnertwo",
                     details: errorspb.EncodedErrorDetails{
@@ -287,8 +287,8 @@ require (?s)outerthree.*outerfour.*innerone.*innertwo
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errbase.opaqueLeaf{
                     msg:     "innerone\ninnertwo",
                     details: errorspb.EncodedErrorDetails{
@@ -363,7 +363,7 @@ Wraps: (4) innerone
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -425,7 +425,7 @@ Wraps: (4) ‹innerone›
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -473,20 +473,20 @@ Wraps: (4) ×
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -519,8 +519,8 @@ opaque
 
 require (?s)innerone.*innertwo
 ----
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errbase.opaqueLeaf{
         msg:     "innerone\ninnertwo",
         details: errorspb.EncodedErrorDetails{
@@ -535,8 +535,8 @@ require (?s)innerone.*innertwo
 ===== non-redactable formats
 =====
 == %#v
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errbase.opaqueLeaf{
         msg:     "innerone\ninnertwo",
         details: errorspb.EncodedErrorDetails{
@@ -567,7 +567,7 @@ innerone
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -596,7 +596,7 @@ Error types: (1) *barriers.barrierError
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -612,13 +612,13 @@ Error types: (1) *barriers.barrierError
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 
@@ -2055,8 +2055,8 @@ opaque
 require (?s)innerone.*innertwo
 ----
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errbase.opaqueLeaf{
             msg:     "innerone\ninnertwo",
             details: errorspb.EncodedErrorDetails{
@@ -2074,8 +2074,8 @@ require (?s)innerone.*innertwo
 =====
 == %#v
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errbase.opaqueLeaf{
             msg:     "innerone\ninnertwo",
             details: errorspb.EncodedErrorDetails{
@@ -2109,7 +2109,7 @@ Wraps: (2) innerone
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -2139,7 +2139,7 @@ Wraps: (2) ‹innerone›
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -2156,15 +2156,15 @@ Wraps: (2) ×
   |   | (opaque error leaf)
   |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: masked error: ×
+*barriers.barrierErr: masked error: ×
 *domains.withDomain: error domain: pkg <path>
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 

--- a/fmttests/testdata/format/wrap-nofmt-via-network
+++ b/fmttests/testdata/format/wrap-nofmt-via-network
@@ -170,27 +170,58 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *ba
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
-*barriers.barrierError: masked error: × (1)
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
-   Error types: (1) *errbase.opaqueLeaf
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -399,26 +430,55 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *er
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×
-×: ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*errutil.withPrefix: assertmsg: × (2)
+<path>:<lineno>: assertmsg: ×: ×
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg: ×
+  | ×
+Wraps: (4) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
-   Error types: (1) *errbase.opaqueLeaf
-== Extra "2: details"
-assertmsg: ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -426,7 +486,7 @@ github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -542,23 +602,24 @@ Error types: (1) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
-   Error types: (1) *errbase.opaqueLeaf
+(1) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -664,10 +725,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrDelegate
 == Extra "error types"
@@ -675,7 +745,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -776,8 +846,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrDelegateEmpty
 == Extra "error types"
@@ -785,7 +863,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -886,8 +964,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrDelegateNoPrefix
 == Extra "error types"
@@ -895,7 +981,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -982,8 +1068,15 @@ Error types: (1) *hintdetail.withDetail (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *hintdetail.withDetail (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *hintdetail.withDetail
 == Extra "error types"
@@ -991,7 +1084,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withDetail (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1076,19 +1169,22 @@ Error types: (1) *domains.withDomain (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) mydomain
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *domains.withDomain (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
-*domains.withDomain: mydomain (1)
-(check the extra data payloads)
-== Extra "1: details"
-mydomain
+*domains.withDomain: mydomain
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::mydomain)
 == Exception 1 (Module: "mydomain")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1175,8 +1271,15 @@ Error types: (1) *fmttests.werrWithElidedCause (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
+(1) ××
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *fmttests.werrWithElidedCause (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrWithElidedCause
 == Extra "error types"
@@ -1184,7 +1287,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrWithElidedCause (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1285,8 +1388,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrEmpty
 == Extra "error types"
@@ -1294,7 +1405,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -1400,10 +1511,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrFmt
 == Extra "error types"
@@ -1411,7 +1531,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1520,10 +1640,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrFmto
 == Extra "error types"
@@ -1531,7 +1660,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1640,10 +1769,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrFmtoDelegate
 == Extra "error types"
@@ -1651,7 +1789,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1757,10 +1895,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrFmtp
 == Extra "error types"
@@ -1768,7 +1915,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1877,10 +2024,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: fmt/*fmt.wrapError
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmt.wrapError
 == Extra "error types"
@@ -1888,7 +2044,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 fmt/*fmt.wrapError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -1989,27 +2145,27 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: masked error: × (1)
-*domains.withDomain: error domain: pkg <path> (2)
-(check the extra data payloads)
-== Extra "1: details"
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
-   Error types: (1) *errbase.opaqueLeaf
-== Extra "2: details"
-error domain: pkg <path>
+(1) error domain: pkg <path>
+Wraps: (2) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *domains.withDomain (2) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: masked error: ×
+*domains.withDomain: error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2096,8 +2252,15 @@ Error types: (1) *hintdetail.withHint (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
+(1) ×
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *hintdetail.withHint (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *hintdetail.withHint
 == Extra "error types"
@@ -2105,7 +2268,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withHint (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2194,21 +2357,24 @@ Error types: (1) *issuelink.withIssueLink (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) issue: https://mysite
+  | detail: outerthree
+  | outerfour
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *issuelink.withIssueLink (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
-*issuelink.withIssueLink: https://mysite (1)
-(check the extra data payloads)
-== Extra "1: details"
-https://mysite
-outerthree
-   outerfour
+*issuelink.withIssueLink: https://mysite
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/issuelink/*issuelink.withIssueLink (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2309,8 +2475,16 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrMigrated
 == Extra "error types"
@@ -2318,7 +2492,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated (some/previous/path/prevpkg.prevType::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -2406,22 +2580,24 @@ Error types: (1) *errutil.withPrefix (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-outerthree
-outerfour: ×
-×
---
+outerthree: ×
+(1) outerthree
+  | outerfour
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errutil.withPrefix (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
-*errutil.withPrefix: outerthree (1)
-(check the extra data payloads)
-== Extra "1: details"
-outerthree
-   outerfour
+*errutil.withPrefix: outerthree
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "outerthree\nouterfour: ×\n×"
+Title: "outerthree: ×"
 (NO STACKTRACE)
 
 run
@@ -2626,18 +2802,57 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 =====
 == Message payload
 <path>:<lineno>: new-style (×
-×) :: ×
-× ::
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+  | Error types: (1) *errbase.opaqueLeaf
+Wraps: (3) new-style (×
+  | ×) :: ×
+  | × ::
+Wraps: (4) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.withNewMessage (4) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
-*errutil.withNewMessage: new-style (× (1)
+*errutil.withNewMessage: new-style (×
 *secondary.withSecondaryError
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style (×
-   ×) :: ×
-   × ::
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withNewMessage (*::)
@@ -2645,7 +2860,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errNoFmt: new-style (×\n×) :: ×\n× ::\nvia *withstack.withStack"
+Title: "*fmttests.errNoFmt: new-style (×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2777,10 +2992,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrNoFmt
 == Extra "error types"
@@ -2788,7 +3012,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -2889,8 +3113,14 @@ Error types: (1) *os.LinkError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 link × ×: ×
-×
---
+(1) link × ×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *os.LinkError (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *os.LinkError
 == Extra "error types"
@@ -2898,7 +3128,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 os/*os.LinkError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "link × ×: ×\n×"
+Title: "link × ×: ×"
 (NO STACKTRACE)
 
 run
@@ -3004,8 +3234,17 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×: ×
-×
---
+(1) ×
+  |
+  | (opaque error wrapper)
+  | type name: net/*net.OpError
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *net.OpError
 == Extra "error types"
@@ -3013,7 +3252,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 net/*net.OpError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -3112,8 +3351,14 @@ Error types: (1) *fs.PathError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 link ×: ×
-×
---
+(1) link ×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *fs.PathError (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fs.PathError
 == Extra "error types"
@@ -3121,7 +3366,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 io/fs/*fs.PathError (os/*os.PathError::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "link ×: ×\n×"
+Title: "link ×: ×"
 (NO STACKTRACE)
 
 run
@@ -3218,8 +3463,14 @@ Error types: (1) *os.SyscallError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 open: ×
-×
---
+(1) open
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *os.SyscallError (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *os.SyscallError
 == Extra "error types"
@@ -3227,7 +3478,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 os/*os.SyscallError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "open: ×\n×"
+Title: "open: ×"
 (NO STACKTRACE)
 
 run
@@ -3337,10 +3588,16 @@ Error types: (1) *errors.withMessage (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
+(1) ××
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errors.withMessage (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *errors.withMessage
 == Extra "error types"
@@ -3348,7 +3605,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/pkg/errors/*errors.withMessage (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -3506,8 +3763,42 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/pkg/errors/*errors.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 <path>:<lineno>: *errors.withStack (top exception)
 == Extra "error types"
@@ -3515,7 +3806,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/pkg/errors/*errors.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errNoFmt: ×\n×\nvia *errors.withStack"
+Title: "*fmttests.errNoFmt: ×\nvia *errors.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3625,20 +3916,23 @@ Error types: (1) *safedetails.withSafeDetails (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) safe ×
+  | ×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *safedetails.withSafeDetails (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
-*safedetails.withSafeDetails: safe × (1)
-(check the extra data payloads)
-== Extra "1: details"
-safe ×
-   ×
+*safedetails.withSafeDetails: safe ×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/safedetails/*safedetails.withSafeDetails (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -3744,10 +4038,19 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-×
 ×: ×
-×
---
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 *fmttests.werrSafeFormat
 == Extra "error types"
@@ -3755,7 +4058,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×: ×\n×"
+Title: "×: ×"
 (NO STACKTRACE)
 
 run
@@ -3764,7 +4067,6 @@ secondary outerthree outerfour
 opaque
 
 require (?s)innerone.*innertwo
-----
 ----
 &secondary.withSecondaryError{
     cause: &errbase.opaqueLeaf{
@@ -3925,50 +4227,56 @@ Error types: (1) *secondary.withSecondaryError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) secondary error attachment
+  | outerthree
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) outerthree
+  |   | outerfour
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *secondary.withSecondaryError (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  outerthree
-   outerfour
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 nofmt innerone innertwo
@@ -4120,8 +4428,42 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
 <path>:<lineno>: *withstack.withStack (top exception)
 == Extra "error types"
@@ -4129,7 +4471,7 @@ github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errNoFmt: ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errNoFmt: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4285,20 +4627,22 @@ Error types: (1) *contexttags.withContext (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) tags: [k×,safe=×]
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *contexttags.withContext (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
-*contexttags.withContext: k× (1)
-(check the extra data payloads)
-== Extra "1: details"
-k×
-safe=456
+*contexttags.withContext: k×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/contexttags/*contexttags.withContext (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -4385,21 +4729,23 @@ Error types: (1) *telemetrykeys.withTelemetry (2) *errbase.opaqueLeaf
 =====
 == Message payload
 ×
-×
---
+(1) keys: [somekey outerthree
+  | outerfour]
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *telemetrykeys.withTelemetry (2) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
-*telemetrykeys.withTelemetry: somekey (1)
-(check the extra data payloads)
-== Extra "1: details"
-somekey
-outerthree
-   outerfour
+*telemetrykeys.withTelemetry: somekey
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*fmttests.errNoFmt"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
 
 run
@@ -4563,24 +4909,55 @@ Error types: (1) *errbase.opaqueWrapper (2) *errutil.withPrefix (3) *errbase.opa
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-stylew ×
-×: ×
-×
---
+<path>:<lineno>: new-stylew ×: ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) new-stylew ×
+  | ×
+Wraps: (3) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *errutil.withPrefix (3) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
-*errutil.withPrefix: new-stylew × (1)
+*errutil.withPrefix: new-stylew ×
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-stylew ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errNoFmt: new-stylew ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errNoFmt: new-stylew ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4612,7 +4989,6 @@ wrapf-attached outerthree outerfour
 opaque
 
 require (?s)outerthree.*outerfour.*innerone.*innertwo
-----
 ----
 &errbase.opaqueWrapper{
     cause: &secondary.withSecondaryError{
@@ -4858,47 +5234,82 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-style ×
-× (payload): ×
-×
---
+<path>:<lineno>: new-style ×: ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | payload
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | × (payload)
+Wraps: (4) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.withPrefix (4) *errbase.opaqueLeaf
+-- report composition:
 *fmttests.errNoFmt
-*errutil.withPrefix: new-style × (1)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
+*errutil.withPrefix: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 <path>:<lineno>: *withstack.withStack (top exception)
-(check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   × (payload)
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 github.com/cockroachdb/errors/fmttests/*fmttests.errNoFmt (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -4906,7 +5317,7 @@ github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*fmttests.errNoFmt: new-style ×\n× (payload): ×\n×\nvia *withstack.withStack"
+Title: "*fmttests.errNoFmt: new-style ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4931,5 +5342,3 @@ Title: "*fmttests.errNoFmt: new-style ×\n× (payload): ×\n×\nvia *withstack.w
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----

--- a/fmttests/testdata/format/wrap-pkgerr
+++ b/fmttests/testdata/format/wrap-pkgerr
@@ -6,8 +6,8 @@ require (?s)
 ----
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errors.fundamental{
                 msg:   "innerone\ninnertwo",
                 stack: &stack{...},
@@ -22,8 +22,8 @@ require (?s)
 == %#v
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errors.fundamental{
                 msg:   "innerone\ninnertwo",
                 stack: &stack{...},
@@ -101,7 +101,7 @@ Wraps: (3) innerone
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -179,7 +179,7 @@ Wraps: (3) ‹innerone›
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -244,18 +244,18 @@ Wraps: (3) ×
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*barriers.barrierErr: details for github.com/pkg/errors/*errors.fundamental:::
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -290,8 +290,8 @@ require (?s)outerthree.*outerfour.*
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errors.fundamental{
                     msg:   "innerone\ninnertwo",
                     stack: &stack{...},
@@ -309,8 +309,8 @@ require (?s)outerthree.*outerfour.*
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errors.fundamental{
                     msg:   "innerone\ninnertwo",
                     stack: &stack{...},
@@ -393,7 +393,7 @@ Wraps: (4) innerone
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -474,7 +474,7 @@ Wraps: (4) ‹innerone›
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -541,20 +541,20 @@ Wraps: (4) ×
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*barriers.barrierErr: details for github.com/pkg/errors/*errors.fundamental:::
 *errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -586,8 +586,8 @@ barrier outerthree outerfour
 
 require (?s)
 ----
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errors.fundamental{
         msg:   "innerone\ninnertwo",
         stack: &stack{...},
@@ -597,8 +597,8 @@ require (?s)
 ===== non-redactable formats
 =====
 == %#v
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errors.fundamental{
         msg:   "innerone\ninnertwo",
         stack: &stack{...},
@@ -646,7 +646,7 @@ innerone
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -697,7 +697,7 @@ Error types: (1) *barriers.barrierError
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -735,13 +735,13 @@ Error types: (1) *barriers.barrierError
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*barriers.barrierErr: details for github.com/pkg/errors/*errors.fundamental:::
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 
@@ -2967,8 +2967,8 @@ handled-domain outerthree outerfour
 require (?s)
 ----
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errors.fundamental{
             msg:   "innerone\ninnertwo",
             stack: &stack{...},
@@ -2981,8 +2981,8 @@ require (?s)
 =====
 == %#v
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errors.fundamental{
             msg:   "innerone\ninnertwo",
             stack: &stack{...},
@@ -3033,7 +3033,7 @@ Wraps: (2) innerone
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -3085,7 +3085,7 @@ Wraps: (2) ‹innerone›
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -3124,15 +3124,15 @@ Wraps: (2) ×
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errors.fundamental
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*barriers.barrierErr: details for github.com/pkg/errors/*errors.fundamental:::
 *domains.withDomain: error domain: pkg <path>
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 

--- a/fmttests/testdata/format/wrap-pkgerr
+++ b/fmttests/testdata/format/wrap-pkgerr
@@ -4,7 +4,6 @@ assertion outerthree outerfour
 
 require (?s)
 ----
-----
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
         cause: &barriers.barrierError{
@@ -186,75 +185,77 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barr
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental::: (1)
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Error types: (1) *errors.fundamental
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/pkg/errors/*errors.fundamental:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-masked error: ×
-   (1) ××
-   ×
-     -- stack trace:
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Error types: (1) *errors.fundamental
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -279,15 +280,12 @@ Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 pkgerr innerone innertwo
 assertwrap outerthree outerfour
 
 require (?s)outerthree.*outerfour.*
-----
 ----
 &assert.withAssertionFailure{
     cause: &withstack.withStack{
@@ -481,74 +479,74 @@ Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *erru
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×
-×: ×
-×
---
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental::: (1)
-*errutil.withPrefix: assertmsg: × (2)
+<path>:<lineno>: assertmsg: ×: ×
+(1) assertion failure
+Wraps: (2) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg: ×
+  | ×
+Wraps: (4) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Error types: (1) *errors.fundamental
+Error types: (1) *assert.withAssertionFailure (2) *withstack.withStack (3) *errutil.withPrefix (4) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/pkg/errors/*errors.fundamental:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-masked error: ×
-   (1) ××
-   ×
-     -- stack trace:
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Error types: (1) *errors.fundamental
-== Extra "2: details"
-assertmsg: ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -556,7 +554,7 @@ github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -581,15 +579,12 @@ Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withSt
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 pkgerr innerone innertwo
 barrier outerthree outerfour
 
 require (?s)
-----
 ----
 &barriers.barrierError{
     msg:       "innerone\ninnertwo",
@@ -708,74 +703,47 @@ Error types: (1) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/pkg/errors/*errors.fundamental:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-masked error: ×
-   (1) ××
-   ×
-     -- stack trace:
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Error types: (1) *errors.fundamental
+(1) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Error types: (1) *errors.fundamental
+Error types: (1) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 pkgerr innerone innertwo
@@ -897,10 +865,39 @@ Error types: (1) *fmttests.werrDelegate (2) *errors.fundamental
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
+<path>:<lineno>: ×: ×
+(1) ××
 ×
---
+×
+×
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrDelegate (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrDelegate
 == Extra "error types"
@@ -908,7 +905,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1045,8 +1042,35 @@ Error types: (1) *fmttests.werrDelegateEmpty (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1)
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrDelegateEmpty (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrDelegateEmpty
 == Extra "error types"
@@ -1054,7 +1078,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1191,8 +1215,35 @@ Error types: (1) *fmttests.werrDelegateNoPrefix (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrDelegateNoPrefix (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrDelegateNoPrefix
 == Extra "error types"
@@ -1200,7 +1251,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1341,8 +1392,36 @@ Error types: (1) *hintdetail.withDetail (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) ×
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *hintdetail.withDetail (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *hintdetail.withDetail
 == Extra "error types"
@@ -1350,7 +1429,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withDetail (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1489,19 +1568,43 @@ Error types: (1) *domains.withDomain (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) mydomain
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *domains.withDomain (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*domains.withDomain: mydomain (1)
-(check the extra data payloads)
-== Extra "1: details"
-mydomain
+*domains.withDomain: mydomain
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::mydomain)
 == Exception 1 (Module: "mydomain")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1642,8 +1745,36 @@ Error types: (1) *fmttests.werrWithElidedCause (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrWithElidedCause (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrWithElidedCause
 == Extra "error types"
@@ -1651,7 +1782,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrWithElidedCause (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1788,8 +1919,35 @@ Error types: (1) *fmttests.werrEmpty (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1)
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrEmpty (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrEmpty
 == Extra "error types"
@@ -1797,7 +1955,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1945,10 +2103,40 @@ Error types: (1) *fmttests.werrFmt (2) *errors.fundamental
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
+<path>:<lineno>: ×: ×
+(1) ××
 ×
---
+×
+×
+×
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrFmt (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrFmt
 == Extra "error types"
@@ -1956,7 +2144,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2131,10 +2319,37 @@ Error types: (1) *fmttests.werrFmto (2) *errors.fundamental
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
+<path>:<lineno>: ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrFmto (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrFmto
 == Extra "error types"
@@ -2142,7 +2357,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2317,10 +2532,37 @@ Error types: (1) *fmttests.werrFmtoDelegate (2) *errors.fundamental
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
+<path>:<lineno>: ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrFmtoDelegate (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrFmtoDelegate
 == Extra "error types"
@@ -2328,7 +2570,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2470,10 +2712,37 @@ Error types: (1) *fmttests.werrFmtp (2) *errors.fundamental
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
+<path>:<lineno>: ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrFmtp (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrFmtp
 == Extra "error types"
@@ -2481,7 +2750,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2627,10 +2896,37 @@ Error types: (1) *fmt.wrapError (2) *errors.fundamental
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
+<path>:<lineno>: ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmt.wrapError (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmt.wrapError
 == Extra "error types"
@@ -2638,7 +2934,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 fmt/*fmt.wrapError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2669,7 +2965,6 @@ pkgerr innerone innertwo
 handled-domain outerthree outerfour
 
 require (?s)
-----
 ----
 &domains.withDomain{
     cause: &barriers.barrierError{
@@ -2796,78 +3091,50 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental::: (1)
-*domains.withDomain: error domain: pkg <path> (2)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/pkg/errors/*errors.fundamental:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-masked error: ×
-   (1) ××
-   ×
-     -- stack trace:
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Error types: (1) *errors.fundamental
-== Extra "2: details"
-error domain: pkg <path>
+(1) error domain: pkg <path>
+Wraps: (2) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ××
+  | ×
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Error types: (1) *errors.fundamental
+Error types: (1) *domains.withDomain (2) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*domains.withDomain: error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 pkgerr innerone innertwo
@@ -2984,8 +3251,36 @@ Error types: (1) *hintdetail.withHint (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) ×
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *hintdetail.withHint (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *hintdetail.withHint
 == Extra "error types"
@@ -2993,7 +3288,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withHint (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3136,21 +3431,45 @@ Error types: (1) *issuelink.withIssueLink (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) issue: https://mysite
+  | detail: outerthree
+  | outerfour
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *issuelink.withIssueLink (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*issuelink.withIssueLink: https://mysite (1)
-(check the extra data payloads)
-== Extra "1: details"
-https://mysite
-outerthree
-   outerfour
+*issuelink.withIssueLink: https://mysite
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/issuelink/*issuelink.withIssueLink (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3287,8 +3606,35 @@ Error types: (1) *fmttests.werrMigrated (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1)
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrMigrated (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrMigrated
 == Extra "error types"
@@ -3296,7 +3642,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated (some/previous/path/prevpkg.prevType::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3438,22 +3784,45 @@ Error types: (1) *errutil.withPrefix (2) *errors.fundamental
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: outerthree
-outerfour: ×
+<path>:<lineno>: outerthree: ×
+(1) outerthree
+  | outerfour
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *errutil.withPrefix (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*errutil.withPrefix: outerthree (1)
-(check the extra data payloads)
-== Extra "1: details"
-outerthree
-   outerfour
+*errutil.withPrefix: outerthree
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: outerthree\nouterfour: ×\n×"
+Title: "*errors.fundamental: outerthree: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3484,7 +3853,6 @@ pkgerr innerone innertwo
 newfw outerthree outerfour
 
 require (?s)outerthree.*outerfour.*
-----
 ----
 &withstack.withStack{
     cause: &secondary.withSecondaryError{
@@ -3687,52 +4055,84 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 =====
 == Message payload
 <path>:<lineno>: new-style (×
-×) :: ×
-× ::
---
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) secondary error attachment
+  | ×
+  | (1) ××
+  | ×
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Error types: (1) *errors.fundamental
+Wraps: (3) new-style (×
+  | ×) :: ×
+  | × ::
+Wraps: (4) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.withNewMessage (4) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*errutil.withNewMessage: new-style (× (1)
-*secondary.withSecondaryError: details for github.com/pkg/errors/*errors.fundamental::: (2)
-<path>:<lineno>: *withstack.withStack (3)
+*errutil.withNewMessage: new-style (×
+*secondary.withSecondaryError: details for github.com/pkg/errors/*errors.fundamental:::
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style (×
-   ×) :: ×
-   × ::
-== Extra "2: details"
-details for github.com/pkg/errors/*errors.fundamental:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withNewMessage (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(3) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -3760,7 +4160,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: new-style (×\n×) :: ×\n× ::"
+Title: "*errors.fundamental: new-style (×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3785,8 +4185,6 @@ Title: "*errors.fundamental: new-style (×\n×) :: ×\n× ::"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 pkgerr innerone innertwo
@@ -3908,10 +4306,37 @@ Error types: (1) *fmttests.werrNoFmt (2) *errors.fundamental
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
+<path>:<lineno>: ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrNoFmt (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrNoFmt
 == Extra "error types"
@@ -3919,7 +4344,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4067,8 +4492,35 @@ Error types: (1) *os.LinkError (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: link × ×: ×
+(1) link × ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *os.LinkError (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *os.LinkError
 == Extra "error types"
@@ -4076,7 +4528,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 os/*os.LinkError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: link × ×: ×\n×"
+Title: "*errors.fundamental: link × ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4226,8 +4678,35 @@ Error types: (1) *net.OpError (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: send tcp ×: ×
+(1) send tcp ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *net.OpError (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *net.OpError
 == Extra "error types"
@@ -4235,7 +4714,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 net/*net.OpError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: send tcp ×: ×\n×"
+Title: "*errors.fundamental: send tcp ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4381,8 +4860,35 @@ Error types: (1) *fs.PathError (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: link ×: ×
+(1) link ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fs.PathError (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fs.PathError
 == Extra "error types"
@@ -4390,7 +4896,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 io/fs/*fs.PathError (os/*os.PathError::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: link ×: ×\n×"
+Title: "*errors.fundamental: link ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4534,8 +5040,35 @@ Error types: (1) *os.SyscallError (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: open: ×
+(1) open
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *os.SyscallError (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *os.SyscallError
 == Extra "error types"
@@ -4543,7 +5076,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 os/*os.SyscallError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: open: ×\n×"
+Title: "*errors.fundamental: open: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4726,10 +5259,37 @@ Error types: (1) *errors.withMessage (2) *errors.fundamental
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
+<path>:<lineno>: ×: ×
+(1) ××
 ×
---
+Wraps: (2) ××
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *errors.withMessage (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *errors.withMessage
 == Extra "error types"
@@ -4737,7 +5297,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/pkg/errors/*errors.withMessage (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4943,8 +5503,39 @@ Error types: (1) *errors.withStack (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1)
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *errors.withStack (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 <path>:<lineno>: *errors.withStack (1)
 (check the extra data payloads)
@@ -4980,7 +5571,7 @@ Title: "*errors.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5121,20 +5712,44 @@ Error types: (1) *safedetails.withSafeDetails (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) safe ×
+  | ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *safedetails.withSafeDetails (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*safedetails.withSafeDetails: safe × (1)
-(check the extra data payloads)
-== Extra "1: details"
-safe ×
-   ×
+*safedetails.withSafeDetails: safe ×
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/safedetails/*safedetails.withSafeDetails (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5276,10 +5891,37 @@ Error types: (1) *fmttests.werrSafeFormat (2) *errors.fundamental
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: safe ×
-×: ×
+<path>:<lineno>: safe ×: ×
+(1) safe ×
+  | ×
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *fmttests.werrSafeFormat (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrSafeFormat
 == Extra "error types"
@@ -5287,7 +5929,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: safe ×\n×: ×\n×"
+Title: "*errors.fundamental: safe ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5318,7 +5960,6 @@ pkgerr innerone innertwo
 secondary outerthree outerfour
 
 require (?s)
-----
 ----
 &secondary.withSecondaryError{
     cause: &errors.fundamental{
@@ -5493,47 +6134,73 @@ Error types: (1) *secondary.withSecondaryError (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) secondary error attachment
+  | outerthree
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) outerthree
+  |   | outerfour
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *secondary.withSecondaryError (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  outerthree
-   outerfour
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5558,8 +6225,6 @@ Title: "*errors.fundamental: ×\n×"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 pkgerr innerone innertwo
@@ -5682,8 +6347,39 @@ Error types: (1) *withstack.withStack (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *withstack.withStack (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 <path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
@@ -5719,7 +6415,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5914,20 +6610,43 @@ Error types: (1) *contexttags.withContext (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) tags: [k×,safe=456]
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *contexttags.withContext (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*contexttags.withContext: k× (1)
-(check the extra data payloads)
-== Extra "1: details"
-k×
-safe=456
+*contexttags.withContext: k×
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/contexttags/*contexttags.withContext (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6068,21 +6787,44 @@ Error types: (1) *telemetrykeys.withTelemetry (2) *errors.fundamental
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) keys: [somekey outerthree
+  | outerfour]
+Wraps: (2) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *telemetrykeys.withTelemetry (2) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*telemetrykeys.withTelemetry: somekey (1)
-(check the extra data payloads)
-== Extra "1: details"
-somekey
-outerthree
-   outerfour
+*telemetrykeys.withTelemetry: somekey
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6240,23 +6982,52 @@ Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *errors.fundam
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-stylew ×
-×: ×
+<path>:<lineno>: new-stylew ×: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) new-stylew ×
+  | ×
+Wraps: (3) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*errutil.withPrefix: new-stylew × (1)
-<path>:<lineno>: *withstack.withStack (2)
+*errutil.withPrefix: new-stylew ×
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-stylew ×
-   ×
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(2) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -6284,7 +7055,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: new-stylew ×\n×: ×\n×"
+Title: "*errors.fundamental: new-stylew ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6315,7 +7086,6 @@ pkgerr innerone innertwo
 wrapf-attached outerthree outerfour
 
 require (?s)outerthree.*outerfour.*
-----
 ----
 &withstack.withStack{
     cause: &secondary.withSecondaryError{
@@ -6515,54 +7285,84 @@ Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *err
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-style ×
-× (payload): ×
+<path>:<lineno>: new-style ×: ×
+(1) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | [...repeated from below...]
+Wraps: (2) secondary error attachment
+  | payload
+  | (1) attached stack trace
+  |   -- stack trace:
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *withstack.withStack (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | × (payload)
+Wraps: (4) ××
 ×
---
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+×
+Error types: (1) *withstack.withStack (2) *secondary.withSecondaryError (3) *errutil.withPrefix (4) *errors.fundamental
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*errutil.withPrefix: new-style × (1)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
-<path>:<lineno>: *withstack.withStack (3)
+*errutil.withPrefix: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   × (payload)
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(3) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -6590,7 +7390,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: new-style ×\n× (payload): ×\n×"
+Title: "*errors.fundamental: new-style ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6615,5 +7415,3 @@ Title: "*errors.fundamental: new-style ×\n× (payload): ×\n×"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----

--- a/fmttests/testdata/format/wrap-pkgerr
+++ b/fmttests/testdata/format/wrap-pkgerr
@@ -219,6 +219,35 @@ details for github.com/pkg/errors/*errors.fundamental:::
    <tab><path>:<lineno>
    runtime.goexit
    <tab><path>:<lineno>
+masked error: ×
+   (1) ××
+   ×
+     -- stack trace:
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Error types: (1) *errors.fundamental
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -488,6 +517,35 @@ details for github.com/pkg/errors/*errors.fundamental:::
    <tab><path>:<lineno>
    runtime.goexit
    <tab><path>:<lineno>
+masked error: ×
+   (1) ××
+   ×
+     -- stack trace:
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Error types: (1) *errors.fundamental
 == Extra "2: details"
 assertmsg: ×
    ×
@@ -681,6 +739,35 @@ details for github.com/pkg/errors/*errors.fundamental:::
    <tab><path>:<lineno>
    runtime.goexit
    <tab><path>:<lineno>
+masked error: ×
+   (1) ××
+   ×
+     -- stack trace:
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Error types: (1) *errors.fundamental
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
@@ -2741,6 +2828,35 @@ details for github.com/pkg/errors/*errors.fundamental:::
    <tab><path>:<lineno>
    runtime.goexit
    <tab><path>:<lineno>
+masked error: ×
+   (1) ××
+   ×
+     -- stack trace:
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Error types: (1) *errors.fundamental
 == Extra "2: details"
 error domain: pkg <path>
 == Extra "error types"

--- a/fmttests/testdata/format/wrap-pkgerr-via-network
+++ b/fmttests/testdata/format/wrap-pkgerr-via-network
@@ -7,8 +7,8 @@ require (?s)innerone.*innertwo
 ----
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errbase.opaqueLeaf{
                 msg:     "innerone\ninnertwo",
                 details: errorspb.EncodedErrorDetails{
@@ -34,8 +34,8 @@ require (?s)innerone.*innertwo
 == %#v
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
-        cause: &barriers.barrierError{
-            msg:       "innerone\ninnertwo",
+        cause: &barriers.barrierErr{
+            smsg:      "‹innerone›\n‹innertwo›",
             maskedErr: &errbase.opaqueLeaf{
                 msg:     "innerone\ninnertwo",
                 details: errorspb.EncodedErrorDetails{
@@ -131,7 +131,7 @@ Wraps: (3) innerone
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -216,7 +216,7 @@ Wraps: (3) ‹innerone›
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -288,18 +288,18 @@ Wraps: (3) ×
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*barriers.barrierErr: details for github.com/pkg/errors/*errors.fundamental:::
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -335,8 +335,8 @@ require (?s)outerthree.*outerfour.*innerone.*innertwo
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errbase.opaqueLeaf{
                     msg:     "innerone\ninnertwo",
                     details: errorspb.EncodedErrorDetails{
@@ -365,8 +365,8 @@ require (?s)outerthree.*outerfour.*innerone.*innertwo
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &errutil.withPrefix{
-            cause: &barriers.barrierError{
-                msg:       "innerone\ninnertwo",
+            cause: &barriers.barrierErr{
+                smsg:      "‹innerone›\n‹innertwo›",
                 maskedErr: &errbase.opaqueLeaf{
                     msg:     "innerone\ninnertwo",
                     details: errorspb.EncodedErrorDetails{
@@ -467,7 +467,7 @@ Wraps: (4) innerone
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -555,7 +555,7 @@ Wraps: (4) ‹innerone›
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -629,20 +629,20 @@ Wraps: (4) ×
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*barriers.barrierErr: details for github.com/pkg/errors/*errors.fundamental:::
 *errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
+Title: "*barriers.barrierErr: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -675,8 +675,8 @@ opaque
 
 require (?s)innerone.*innertwo
 ----
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errbase.opaqueLeaf{
         msg:     "innerone\ninnertwo",
         details: errorspb.EncodedErrorDetails{
@@ -691,8 +691,8 @@ require (?s)innerone.*innertwo
 ===== non-redactable formats
 =====
 == %#v
-&barriers.barrierError{
-    msg:       "innerone\ninnertwo",
+&barriers.barrierErr{
+    smsg:      "‹innerone›\n‹innertwo›",
     maskedErr: &errbase.opaqueLeaf{
         msg:     "innerone\ninnertwo",
         details: errorspb.EncodedErrorDetails{
@@ -749,7 +749,7 @@ innerone
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -804,7 +804,7 @@ Error types: (1) *barriers.barrierError
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -846,13 +846,13 @@ Error types: (1) *barriers.barrierError
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *barriers.barrierError
+Error types: (1) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*barriers.barrierErr: details for github.com/pkg/errors/*errors.fundamental:::
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 
@@ -3501,8 +3501,8 @@ opaque
 require (?s)innerone.*innertwo
 ----
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errbase.opaqueLeaf{
             msg:     "innerone\ninnertwo",
             details: errorspb.EncodedErrorDetails{
@@ -3520,8 +3520,8 @@ require (?s)innerone.*innertwo
 =====
 == %#v
 &domains.withDomain{
-    cause: &barriers.barrierError{
-        msg:       "innerone\ninnertwo",
+    cause: &barriers.barrierErr{
+        smsg:      "‹innerone›\n‹innertwo›",
         maskedErr: &errbase.opaqueLeaf{
             msg:     "innerone\ninnertwo",
             details: errorspb.EncodedErrorDetails{
@@ -3581,7 +3581,7 @@ Wraps: (2) innerone
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 == %#v via Formattable() = %#v, good
 == %v via Formattable() = Error(), good
 == %s via Formattable() = %v via Formattable(), good
@@ -3637,7 +3637,7 @@ Wraps: (2) ‹innerone›
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 =====
 ===== Sentry reporting
 =====
@@ -3680,15 +3680,15 @@ Wraps: (2) ×
   |   | runtime.goexit
   |   | <tab><path>:<lineno>
   | Error types: (1) *errbase.opaqueLeaf
-Error types: (1) *domains.withDomain (2) *barriers.barrierError
+Error types: (1) *domains.withDomain (2) *barriers.barrierErr
 -- report composition:
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*barriers.barrierErr: details for github.com/pkg/errors/*errors.fundamental:::
 *domains.withDomain: error domain: pkg <path>
 == Extra "error types"
-github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
+github.com/cockroachdb/errors/barriers/*barriers.barrierErr (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
-Type: "*barriers.barrierError"
+Type: "*barriers.barrierErr"
 Title: "×"
 (NO STACKTRACE)
 

--- a/fmttests/testdata/format/wrap-pkgerr-via-network
+++ b/fmttests/testdata/format/wrap-pkgerr-via-network
@@ -256,6 +256,39 @@ details for github.com/pkg/errors/*errors.fundamental:::
    <tab><path>:<lineno>
    runtime.goexit
    <tab><path>:<lineno>
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/pkg/errors/*errors.fundamental
+     | reportable 0:
+     |
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Error types: (1) *errbase.opaqueLeaf
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
@@ -562,6 +595,39 @@ details for github.com/pkg/errors/*errors.fundamental:::
    <tab><path>:<lineno>
    runtime.goexit
    <tab><path>:<lineno>
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/pkg/errors/*errors.fundamental
+     | reportable 0:
+     |
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Error types: (1) *errbase.opaqueLeaf
 == Extra "2: details"
 assertmsg: ×
    ×
@@ -774,6 +840,39 @@ details for github.com/pkg/errors/*errors.fundamental:::
    <tab><path>:<lineno>
    runtime.goexit
    <tab><path>:<lineno>
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/pkg/errors/*errors.fundamental
+     | reportable 0:
+     |
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Error types: (1) *errbase.opaqueLeaf
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
@@ -3196,6 +3295,39 @@ details for github.com/pkg/errors/*errors.fundamental:::
    <tab><path>:<lineno>
    runtime.goexit
    <tab><path>:<lineno>
+masked error: ×
+   (1) ×
+     | ×
+     |
+     | (opaque error leaf)
+     | type name: github.com/pkg/errors/*errors.fundamental
+     | reportable 0:
+     |
+     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective.func1
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirective
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.runTestInternal
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.RunTest
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk
+     | <tab><path>:<lineno>
+     | github.com/cockroachdb/datadriven.Walk.func1
+     | <tab><path>:<lineno>
+     | testing.tRunner
+     | <tab><path>:<lineno>
+     | runtime.goexit
+     | <tab><path>:<lineno>
+   Error types: (1) *errbase.opaqueLeaf
 == Extra "2: details"
 error domain: pkg <path>
 == Extra "error types"

--- a/fmttests/testdata/format/wrap-pkgerr-via-network
+++ b/fmttests/testdata/format/wrap-pkgerr-via-network
@@ -5,7 +5,6 @@ opaque
 
 require (?s)innerone.*innertwo
 ----
-----
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
         cause: &barriers.barrierError{
@@ -223,79 +222,84 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *ba
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental::: (1)
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/pkg/errors/*errors.fundamental
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/pkg/errors/*errors.fundamental:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/pkg/errors/*errors.fundamental
-     | reportable 0:
-     |
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Error types: (1) *errbase.opaqueLeaf
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -320,8 +324,6 @@ Title: "*barriers.barrierError: ×\n×\nvia *withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 pkgerr innerone innertwo
@@ -329,7 +331,6 @@ assertwrap outerthree outerfour
 opaque
 
 require (?s)outerthree.*outerfour.*innerone.*innertwo
-----
 ----
 &assert.withAssertionFailure{
     cause: &errbase.opaqueWrapper{
@@ -559,78 +560,81 @@ Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *er
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: assertmsg: ×
-×: ×
-×
---
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental::: (1)
-*errutil.withPrefix: assertmsg: × (2)
+<path>:<lineno>: assertmsg: ×: ×
+(1) assertion failure
+Wraps: (2)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (3) assertmsg: ×
+  | ×
+Wraps: (4) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/pkg/errors/*errors.fundamental
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *assert.withAssertionFailure (2) *errbase.opaqueWrapper (3) *errutil.withPrefix (4) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*errutil.withPrefix: assertmsg: ×
 <path>:<lineno>: *withstack.withStack (top exception)
 *assert.withAssertionFailure
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/pkg/errors/*errors.fundamental:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/pkg/errors/*errors.fundamental
-     | reportable 0:
-     |
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Error types: (1) *errbase.opaqueLeaf
-== Extra "2: details"
-assertmsg: ×
-   ×
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
@@ -638,7 +642,7 @@ github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withStack"
+Title: "*barriers.barrierError: assertmsg: ×: ×\nvia *withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -663,8 +667,6 @@ Title: "*barriers.barrierError: assertmsg: ×\n×: ×\n×\nvia *withstack.withSt
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 pkgerr innerone innertwo
@@ -672,7 +674,6 @@ barrier outerthree outerfour
 opaque
 
 require (?s)innerone.*innertwo
-----
 ----
 &barriers.barrierError{
     msg:       "innerone\ninnertwo",
@@ -809,78 +810,51 @@ Error types: (1) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/pkg/errors/*errors.fundamental:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/pkg/errors/*errors.fundamental
-     | reportable 0:
-     |
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Error types: (1) *errbase.opaqueLeaf
+(1) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/pkg/errors/*errors.fundamental
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 pkgerr innerone innertwo
@@ -1037,10 +1011,45 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
-×
---
+<path>:<lineno>: ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrDelegate
 == Extra "error types"
@@ -1048,7 +1057,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1224,8 +1233,42 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrDelegateEmpty
 == Extra "error types"
@@ -1233,7 +1276,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1409,8 +1452,42 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrDelegateNoPrefix
 == Extra "error types"
@@ -1418,7 +1495,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrDelegateNoPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1580,8 +1657,41 @@ Error types: (1) *hintdetail.withDetail (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) ×
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *hintdetail.withDetail (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *hintdetail.withDetail
 == Extra "error types"
@@ -1589,7 +1699,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withDetail (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1749,19 +1859,48 @@ Error types: (1) *domains.withDomain (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1) mydomain
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *domains.withDomain (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*domains.withDomain: mydomain (1)
-(check the extra data payloads)
-== Extra "1: details"
-mydomain
+*domains.withDomain: mydomain
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::mydomain)
 == Exception 1 (Module: "mydomain")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -1923,8 +2062,41 @@ Error types: (1) *fmttests.werrWithElidedCause (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) ××
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *fmttests.werrWithElidedCause (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrWithElidedCause
 == Extra "error types"
@@ -1932,7 +2104,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrWithElidedCause (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2108,8 +2280,42 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrEmpty
 == Extra "error types"
@@ -2117,7 +2323,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrEmpty (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2298,10 +2504,45 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
-×
---
+<path>:<lineno>: ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrFmt
 == Extra "error types"
@@ -2309,7 +2550,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2493,10 +2734,45 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
-×
---
+<path>:<lineno>: ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrFmto
 == Extra "error types"
@@ -2504,7 +2780,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmto (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2688,10 +2964,45 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
-×
---
+<path>:<lineno>: ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrFmtoDelegate
 == Extra "error types"
@@ -2699,7 +3010,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtoDelegate (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -2880,10 +3191,45 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
-×
---
+<path>:<lineno>: ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrFmtp
 == Extra "error types"
@@ -2891,7 +3237,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrFmtp (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3075,10 +3421,45 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
-×
---
+<path>:<lineno>: ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: fmt/*fmt.wrapError
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmt.wrapError
 == Extra "error types"
@@ -3086,7 +3467,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 fmt/*fmt.wrapError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3118,7 +3499,6 @@ handled-domain outerthree outerfour
 opaque
 
 require (?s)innerone.*innertwo
-----
 ----
 &domains.withDomain{
     cause: &barriers.barrierError{
@@ -3263,82 +3643,54 @@ Error types: (1) *domains.withDomain (2) *barriers.barrierError
 =====
 == Message payload
 ×
-×
---
-*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental::: (1)
-*domains.withDomain: error domain: pkg <path> (2)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/pkg/errors/*errors.fundamental:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-masked error: ×
-   (1) ×
-     | ×
-     |
-     | (opaque error leaf)
-     | type name: github.com/pkg/errors/*errors.fundamental
-     | reportable 0:
-     |
-     | github.com/cockroachdb/errors/fmttests.glob...funcNN...
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective.func1
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirective
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.runTestInternal
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.RunTest
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk
-     | <tab><path>:<lineno>
-     | github.com/cockroachdb/datadriven.Walk.func1
-     | <tab><path>:<lineno>
-     | testing.tRunner
-     | <tab><path>:<lineno>
-     | runtime.goexit
-     | <tab><path>:<lineno>
-   Error types: (1) *errbase.opaqueLeaf
-== Extra "2: details"
-error domain: pkg <path>
+(1) error domain: pkg <path>
+Wraps: (2) ×
+  | ×
+  | -- cause hidden behind barrier
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/pkg/errors/*errors.fundamental
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Error types: (1) *errbase.opaqueLeaf
+Error types: (1) *domains.withDomain (2) *barriers.barrierError
+-- report composition:
+*barriers.barrierError: details for github.com/pkg/errors/*errors.fundamental:::
+*domains.withDomain: error domain: pkg <path>
 == Extra "error types"
 github.com/cockroachdb/errors/barriers/*barriers.barrierError (*::)
 github.com/cockroachdb/errors/domains/*domains.withDomain (*::error domain: pkg <path>)
 == Exception 1 (Module: "error domain: pkg <path>")
 Type: "*barriers.barrierError"
-Title: "×\n×"
+Title: "×"
 (NO STACKTRACE)
-----
-----
 
 run
 pkgerr innerone innertwo
@@ -3476,8 +3828,41 @@ Error types: (1) *hintdetail.withHint (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
+(1) ×
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *hintdetail.withHint (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *hintdetail.withHint
 == Extra "error types"
@@ -3485,7 +3870,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/hintdetail/*hintdetail.withHint (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3649,21 +4034,50 @@ Error types: (1) *issuelink.withIssueLink (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1) issue: https://mysite
+  | detail: outerthree
+  | outerfour
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *issuelink.withIssueLink (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*issuelink.withIssueLink: https://mysite (1)
-(check the extra data payloads)
-== Extra "1: details"
-https://mysite
-outerthree
-   outerfour
+*issuelink.withIssueLink: https://mysite
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/issuelink/*issuelink.withIssueLink (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -3839,8 +4253,42 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrMigrated
 == Extra "error types"
@@ -3848,7 +4296,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrMigrated (some/previous/path/prevpkg.prevType::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4011,22 +4459,50 @@ Error types: (1) *errutil.withPrefix (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: outerthree
-outerfour: ×
-×
---
+<path>:<lineno>: outerthree: ×
+(1) outerthree
+  | outerfour
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errutil.withPrefix (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*errutil.withPrefix: outerthree (1)
-(check the extra data payloads)
-== Extra "1: details"
-outerthree
-   outerfour
+*errutil.withPrefix: outerthree
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: outerthree\nouterfour: ×\n×"
+Title: "*errors.fundamental: outerthree: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4058,7 +4534,6 @@ newfw outerthree outerfour
 opaque
 
 require (?s)outerthree.*outerfour.*innerone.*innertwo
-----
 ----
 &errbase.opaqueWrapper{
     cause: &secondary.withSecondaryError{
@@ -4359,52 +4834,117 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 =====
 == Message payload
 <path>:<lineno>: new-style (×
-×) :: ×
-× ::
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | ×
+  | (1) ×
+  |   | ×
+  |   |
+  |   | (opaque error leaf)
+  |   | type name: github.com/pkg/errors/*errors.fundamental
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Error types: (1) *errbase.opaqueLeaf
+Wraps: (3) new-style (×
+  | ×) :: ×
+  | × ::
+Wraps: (4) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.withNewMessage (4) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*errutil.withNewMessage: new-style (× (1)
-*secondary.withSecondaryError: details for github.com/pkg/errors/*errors.fundamental::: (2)
-<path>:<lineno>: *withstack.withStack (3)
+*errutil.withNewMessage: new-style (×
+*secondary.withSecondaryError: details for github.com/pkg/errors/*errors.fundamental:::
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style (×
-   ×) :: ×
-   × ::
-== Extra "2: details"
-details for github.com/pkg/errors/*errors.fundamental:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withNewMessage (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(3) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -4432,7 +4972,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: new-style (×\n×) :: ×\n× ::"
+Title: "*errors.fundamental: new-style (×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4457,8 +4997,6 @@ Title: "*errors.fundamental: new-style (×\n×) :: ×\n× ::"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 pkgerr innerone innertwo
@@ -4618,10 +5156,45 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
-×
---
+<path>:<lineno>: ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrNoFmt
 == Extra "error types"
@@ -4629,7 +5202,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrNoFmt (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4805,8 +5378,40 @@ Error types: (1) *os.LinkError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: link × ×: ×
-×
---
+(1) link × ×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *os.LinkError (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *os.LinkError
 == Extra "error types"
@@ -4814,7 +5419,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 os/*os.LinkError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: link × ×: ×\n×"
+Title: "*errors.fundamental: link × ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -4995,8 +5600,43 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×: ×
-×
---
+(1) ×
+  |
+  | (opaque error wrapper)
+  | type name: net/*net.OpError
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *net.OpError
 == Extra "error types"
@@ -5004,7 +5644,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 net/*net.OpError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5178,8 +5818,40 @@ Error types: (1) *fs.PathError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: link ×: ×
-×
---
+(1) link ×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *fs.PathError (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fs.PathError
 == Extra "error types"
@@ -5187,7 +5859,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 io/fs/*fs.PathError (os/*os.PathError::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: link ×: ×\n×"
+Title: "*errors.fundamental: link ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5359,8 +6031,40 @@ Error types: (1) *os.SyscallError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: open: ×
-×
---
+(1) open
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *os.SyscallError (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *os.SyscallError
 == Extra "error types"
@@ -5368,7 +6072,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 os/*os.SyscallError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: open: ×\n×"
+Title: "*errors.fundamental: open: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5579,10 +6283,42 @@ Error types: (1) *errors.withMessage (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
+<path>:<lineno>: ×: ×
+(1) ××
 ×
---
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errors.withMessage (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *errors.withMessage
 == Extra "error types"
@@ -5590,7 +6326,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/pkg/errors/*errors.withMessage (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -5823,8 +6559,68 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/pkg/errors/*errors.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 <path>:<lineno>: *errors.withStack (1)
 (check the extra data payloads)
@@ -5860,7 +6656,7 @@ Title: "*errors.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6022,20 +6818,49 @@ Error types: (1) *safedetails.withSafeDetails (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1) safe ×
+  | ×
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *safedetails.withSafeDetails (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*safedetails.withSafeDetails: safe × (1)
-(check the extra data payloads)
-== Extra "1: details"
-safe ×
-   ×
+*safedetails.withSafeDetails: safe ×
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/safedetails/*safedetails.withSafeDetails (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6216,10 +7041,45 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: ×
-×: ×
-×
---
+<path>:<lineno>: ×: ×
+(1) ×
+  | ×
+  |
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 *fmttests.werrSafeFormat
 == Extra "error types"
@@ -6227,7 +7087,7 @@ github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/fmttests/*fmttests.werrSafeFormat (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×: ×\n×"
+Title: "*errors.fundamental: ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6259,7 +7119,6 @@ secondary outerthree outerfour
 opaque
 
 require (?s)innerone.*innertwo
-----
 ----
 &secondary.withSecondaryError{
     cause: &errbase.opaqueLeaf{
@@ -6472,47 +7331,81 @@ Error types: (1) *secondary.withSecondaryError (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1) secondary error attachment
+  | outerthree
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) outerthree
+  |   | outerfour
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *secondary.withSecondaryError (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (1)
-(check the extra data payloads)
-== Extra "1: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  outerthree
-   outerfour
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6537,8 +7430,6 @@ Title: "*errors.fundamental: ×\n×"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----
 
 run
 pkgerr innerone innertwo
@@ -6742,8 +7633,68 @@ Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
 <path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
@@ -6779,7 +7730,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -6987,20 +7938,48 @@ Error types: (1) *contexttags.withContext (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1) tags: [k×,safe=×]
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *contexttags.withContext (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*contexttags.withContext: k× (1)
-(check the extra data payloads)
-== Extra "1: details"
-k×
-safe=456
+*contexttags.withContext: k×
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/contexttags/*contexttags.withContext (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -7162,21 +8141,49 @@ Error types: (1) *telemetrykeys.withTelemetry (2) *errbase.opaqueLeaf
 =====
 == Message payload
 <path>:<lineno>: ×
-×
---
+(1) keys: [somekey outerthree
+  | outerfour]
+Wraps: (2) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *telemetrykeys.withTelemetry (2) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*telemetrykeys.withTelemetry: somekey (1)
-(check the extra data payloads)
-== Extra "1: details"
-somekey
-outerthree
-   outerfour
+*telemetrykeys.withTelemetry: somekey
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)
 == Exception 1 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: ×\n×"
+Title: "*errors.fundamental: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -7415,23 +8422,81 @@ Error types: (1) *errbase.opaqueWrapper (2) *errutil.withPrefix (3) *errbase.opa
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-stylew ×
-×: ×
-×
---
+<path>:<lineno>: new-stylew ×: ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) new-stylew ×
+  | ×
+Wraps: (3) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *errutil.withPrefix (3) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*errutil.withPrefix: new-stylew × (1)
-<path>:<lineno>: *withstack.withStack (2)
+*errutil.withPrefix: new-stylew ×
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-stylew ×
-   ×
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(2) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -7459,7 +8524,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: new-stylew ×\n×: ×\n×"
+Title: "*errors.fundamental: new-stylew ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -7491,7 +8556,6 @@ wrapf-attached outerthree outerfour
 opaque
 
 require (?s)outerthree.*outerfour.*innerone.*innertwo
-----
 ----
 &errbase.opaqueWrapper{
     cause: &secondary.withSecondaryError{
@@ -7789,54 +8853,116 @@ Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *e
 ===== Sentry reporting
 =====
 == Message payload
-<path>:<lineno>: new-style ×
-× (payload): ×
-×
---
+<path>:<lineno>: new-style ×: ×
+(1)
+  | (opaque error wrapper)
+  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Wraps: (2) secondary error attachment
+  | payload
+  | (1)
+  |   | (opaque error wrapper)
+  |   | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
+  |   | reportable 0:
+  |   |
+  |   | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective.func1
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirective
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.runTestInternal
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.RunTest
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk
+  |   | <tab><path>:<lineno>
+  |   | github.com/cockroachdb/datadriven.Walk.func1
+  |   | <tab><path>:<lineno>
+  |   | testing.tRunner
+  |   | <tab><path>:<lineno>
+  |   | runtime.goexit
+  |   | <tab><path>:<lineno>
+  | Wraps: (2) payload
+  | Error types: (1) *errbase.opaqueWrapper (2) *errutil.leafError
+Wraps: (3) new-style ×
+  | × (payload)
+Wraps: (4) ×
+  | ×
+  |
+  | (opaque error leaf)
+  | type name: github.com/pkg/errors/*errors.fundamental
+  | reportable 0:
+  |
+  | github.com/cockroachdb/errors/fmttests.glob...funcNN...
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective.func1
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirective
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runDirectiveOrSubTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.runTestInternal
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.RunTest
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk
+  | <tab><path>:<lineno>
+  | github.com/cockroachdb/datadriven.Walk.func1
+  | <tab><path>:<lineno>
+  | testing.tRunner
+  | <tab><path>:<lineno>
+  | runtime.goexit
+  | <tab><path>:<lineno>
+Error types: (1) *errbase.opaqueWrapper (2) *secondary.withSecondaryError (3) *errutil.withPrefix (4) *errbase.opaqueLeaf
+-- report composition:
 <path>:<lineno>: *errors.fundamental (top exception)
-*errutil.withPrefix: new-style × (1)
-*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack::: (2)
-<path>:<lineno>: *withstack.withStack (3)
+*errutil.withPrefix: new-style ×
+*secondary.withSecondaryError: details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
+<path>:<lineno>: *withstack.withStack (1)
 (check the extra data payloads)
-== Extra "1: details"
-new-style ×
-   × (payload)
-== Extra "2: details"
-details for github.com/cockroachdb/errors/withstack/*withstack.withStack:::
-  
-   github.com/cockroachdb/errors/fmttests.glob...funcNN...
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2.1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective.func1
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirective
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runDirectiveOrSubTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.runTestInternal
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.RunTest
-   <tab><path>:<lineno>
-   github.com/cockroachdb/errors/fmttests.TestDatadriven.func2
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk
-   <tab><path>:<lineno>
-   github.com/cockroachdb/datadriven.Walk.func1
-   <tab><path>:<lineno>
-   testing.tRunner
-   <tab><path>:<lineno>
-   runtime.goexit
-   <tab><path>:<lineno>
-details for github.com/cockroachdb/errors/errutil/*errutil.leafError:::
-  payload
 == Extra "error types"
 github.com/pkg/errors/*errors.fundamental (*::)
 github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)
 github.com/cockroachdb/errors/secondary/*secondary.withSecondaryError (*::)
 github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)
 == Exception 1 (Module: "error domain: <none>")
-Type: "(3) <path>:<lineno> ...funcNN...
+Type: "(1) <path>:<lineno> ...funcNN...
 Title: "*withstack.withStack"
 <path>:<lineno>:
    (runtime) goexit()
@@ -7864,7 +8990,7 @@ Title: "*withstack.withStack"
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
 == Exception 2 (Module: "error domain: <none>")
 Type: "<path>:<lineno> ...funcNN...
-Title: "*errors.fundamental: new-style ×\n× (payload): ×\n×"
+Title: "*errors.fundamental: new-style ×: ×"
 <path>:<lineno>:
    (runtime) goexit()
 <path>:<lineno>:
@@ -7889,5 +9015,3 @@ Title: "*errors.fundamental: new-style ×\n× (payload): ×\n×"
    (github.com/cockroachdb/errors/fmttests.TestDatadriven.func2) 1()
 <path>:<lineno>:
    (github.com/cockroachdb/errors/fmttests.glob.)...funcNN...
-----
-----

--- a/report/report.go
+++ b/report/report.go
@@ -15,7 +15,6 @@
 package report
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 
@@ -23,7 +22,7 @@ import (
 	"github.com/cockroachdb/errors/errbase"
 	"github.com/cockroachdb/errors/withstack"
 	"github.com/cockroachdb/redact"
-	"github.com/getsentry/sentry-go"
+	sentry "github.com/getsentry/sentry-go"
 )
 
 // BuildSentryReport builds the components of a sentry report.  This
@@ -76,13 +75,13 @@ import (
 // Given this mapping, an error object is decomposed as follows:
 //
 // (1)/(7): <filename>:<lineno> (<functionname>)
-// (3)/(8): <error type>: <first safe detail line, if any>
+// (3)/(8): first line of verbose error printout
 // (4): not populated in this function, caller is to manage this
-// (5): detailed structure of the entire error object, with references to "additional data"
-//      and additional "exception" objects
+// (5): detailed structure of the entire error object, with references to
+//      additional "exception" objects
 // (9): generated from innermost stack trace
 // (6): every exception object after the 1st reports additional stack trace contexts
-// (11): "additional data" populated from safe detail payloads
+// (11): the detailed error types and their error mark.
 //
 // If there is no stack trace in the error, a synthetic Exception
 // object is still produced to provide visual detail in the Sentry UI.
@@ -119,17 +118,22 @@ func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]
 	var firstDetailLine string
 
 	// longMsgBuf will become the Message field, which contains the full
-	// structure of the error with cross-references to "Exception" and
-	// "Additional data" fields.
+	// structure of the error.
 	var longMsgBuf strings.Builder
-	redactedErrStr := redact.Sprint(err).Redact()
-	if redactedErrStr != redactedMarker {
-		if f, l, _, ok := withstack.GetOneLineSource(err); ok {
-			fmt.Fprintf(&longMsgBuf, "%s:%d: ", f, l)
-		}
-		firstDetailLine = redactedErrStr.StripMarkers()
-		fmt.Fprintf(&longMsgBuf, "%v\n--\n", firstDetailLine)
+	if f, l, _, ok := withstack.GetOneLineSource(err); ok {
+		fmt.Fprintf(&longMsgBuf, "%s:%d: ", f, l)
 	}
+	// Include the verbose error printout, with sensitive bits redacted out.
+	verboseErr := redact.Sprintf("%+v", err).Redact().StripMarkers()
+	if verboseErr != redactedMarker {
+		idx := strings.IndexByte(verboseErr, '\n')
+		if idx == -1 {
+			firstDetailLine = verboseErr
+		} else {
+			firstDetailLine = verboseErr[:idx]
+		}
+	}
+	fmt.Fprint(&longMsgBuf, verboseErr)
 
 	// sep is used to separate the entries in the longMsgBuf / Message
 	// payload.
@@ -159,6 +163,7 @@ func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]
 	// layer. We iterate in this order because we want to describe the
 	// error from innermost to outermost layer in longMsgBuf and
 	// typesBuf.
+	longMsgBuf.WriteString("\n-- report composition:\n")
 	for i := len(details) - 1; i >= 0; i-- {
 		// Collect the type name for this layer of error wrapping, towards
 		// the "error types" additional data field.
@@ -204,10 +209,6 @@ func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]
 		// Now decide what kind of payload we want to add to the Event
 		// object.
 
-		// genExtra will remember whether we are adding an
-		// additional payload or not.
-		var genExtra bool
-
 		// Is there a stack trace?
 		if st := stacks[i]; st != nil {
 			var excType strings.Builder
@@ -245,17 +246,21 @@ func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]
 			exceptions = append(exceptions, exc)
 		} else {
 			// No stack trace.
-			// Are there safe details? If so, print them.
+			// Are there safe details? If so, print the first safe detail
+			// string (we're assuming that all the important bits will
+			// also be included in the verbose printout, so there's no
+			// need to dig out more safe strings here.)
+			//
+			// TODO(knz): the SafeDetails API is not really meant for Sentry
+			// reporting. Once we have more experience to prove that the
+			// verbose printout is sufficient, we can remove the SafeDetails
+			// from sentry reports.
 			//
 			// Note: we only print the details if no stack trace was found
 			// at that level. This is because stack trace annotations also
 			// produce the stack trace as safe detail string.
-			genExtra = len(details[i].SafeDetails) > 1
 			if len(details[i].SafeDetails) > 0 {
 				d := details[i].SafeDetails[0]
-				if d != "" {
-					genExtra = true
-				}
 				if j := strings.IndexByte(d, '\n'); j >= 0 {
 					d = d[:j]
 				}
@@ -268,18 +273,6 @@ func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]
 					}
 				}
 			}
-		}
-
-		// Are we generating another extra for the safe detail strings?
-		if genExtra {
-			stKey := fmt.Sprintf("%d: details", extraNum)
-			var extraStr bytes.Buffer
-			for _, d := range details[i].SafeDetails {
-				fmt.Fprintln(&extraStr, strings.ReplaceAll(d, "\n", "\n   "))
-			}
-			extras[stKey] = extraStr.String()
-			fmt.Fprintf(&longMsgBuf, " (%d)", extraNum)
-			extraNum++
 		}
 	}
 
@@ -354,7 +347,7 @@ func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]
 	return event, extras
 }
 
-var redactedMarker = redact.RedactableString(redact.RedactedMarker())
+var redactedMarker = redact.RedactableString(redact.RedactedMarker()).StripMarkers()
 
 // ReportError reports the given error to Sentry. The caller is responsible for
 // checking whether telemetry is enabled, and calling the sentry.Flush()

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/errors/safedetails"
 	"github.com/cockroachdb/errors/testutils"
 	"github.com/cockroachdb/errors/withstack"
-	"github.com/getsentry/sentry-go"
+	sentry "github.com/getsentry/sentry-go"
 	"github.com/kr/pretty"
 )
 
@@ -44,12 +44,12 @@ import (
 //
 // 	myErr := errutil.Newf("Hello %s %d", "world", redact.Safe(123))
 // 	myErr = errutil.Wrapf(myErr, "some prefix %s", "unseen")
+// 	myErr = errutil.NewAssertionErrorWithWrappedErrf(myErr, "assert %s %s", redact.Safe("safe"), "unsafe")
 //
 // 	if eventID := report.ReportError(myErr); eventID == "" {
 // 		t.Fatal("eventID is empty")
 // 	}
 // 	sentry.Flush(2 * time.Second)
-//
 // }
 
 func TestReport(t *testing.T) {
@@ -94,12 +94,28 @@ func TestReport(t *testing.T) {
 	e := events[0]
 
 	tt.Run("long message payload", func(tt testutils.T) {
-		expectedLongMessage := `^\*errors.errorString
-\*safedetails.withSafeDetails: universe 123 multi \(1\)
-report_test.go:\d+: \*withstack.withStack \(top exception\)
-\*domains\.withDomain: error domain: "thisdomain" \(2\)
-\*report_test\.myWrapper
-\(check the extra data payloads\)$`
+		expectedLongMessage := `^
+report_test.go:\d+: ×
+\(1\)
+Wraps: \(2\) error domain: \"thisdomain\"
+Wraps: \(3\) attached stack trace
+  -- stack trace:
+  | github.com/cockroachdb/errors/report_test.TestReport
+  | \t[^:]*report/report_test.go:\d+
+  | testing.tRunner
+  | \t.*src/testing/testing.go:\d+
+  | runtime.goexit
+  | \t[^:]*:\d+
+Wraps: \(4\) universe 123 multi
+  | line
+Wraps: \(5\) ×
+Error types: \(1\) *report_test.myWrapper \(2\) *domains.withDomain \(3\) *withstack.withStack \(4\) *safedetails.withSafeDetails \(5\) *errors.errorString
+-- report composition:
+*errors.errorString
+*safedetails.withSafeDetails: universe 123 multi
+report_test.go:82: *withstack.withStack \(top exception\)
+*domains.withDomain: error domain: \"thisdomain\"
+*report_test.myWrapper$`
 		tt.CheckRegexpEqual(e.Message, expectedLongMessage)
 	})
 
@@ -112,15 +128,6 @@ github.com/cockroachdb/errors/report_test/*report_test.myWrapper (some/previous/
 `
 		types := fmt.Sprintf("%s", e.Extra["error types"])
 		tt.CheckEqual(types, expectedTypes)
-
-		expectedDetail := `universe 123 multi
-   line`
-		detail := fmt.Sprintf("%s", e.Extra["1: details"])
-		tt.CheckEqual(strings.TrimSpace(detail), expectedDetail)
-
-		expectedDetail = string(thisDomain)
-		detail = fmt.Sprintf("%s", e.Extra["2: details"])
-		tt.CheckEqual(strings.TrimSpace(detail), expectedDetail)
 	})
 
 	hasStack := false


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/76571.

This PR includes a redacted copy of the verbose error printout in the Message field of Sentry reports.

This, arguably, was desirable from the beginning, but was impossible when the `errors` library was first designed, because at the time we did not have a reliable redaction library. Now that we have one, we can use it.

The main visible improvement resulting from this PR is the verbose (and tree-preserving) printout of the error hidden behind barriers (e.g. those included behind assertion failures). However, this change will also now include more details about other situations, such as:

- known Go runtime errors (e.g. context canceled, os.PathError, etc)
- custom error types that have a safe formatter function even though they don't report safe strings via the SafeDetails interface
- the tree structure of secondary errors

(and more generally leverages the full power of the recently redesigned errors.FormatError code)

For example, given the starting point Go code:
```go
myErr := errutil.Newf("Hello %s %d", "world", redact.Safe(123))
myErr = errutil.Wrapf(myErr, "some prefix %s", "unseen")
myErr = errutil.NewAssertionErrorWithWrappedErrf(myErr, "assert %s %s", redact.Safe("safe"), "unsafe")
```

Example, before:
![image](https://user-images.githubusercontent.com/642886/156786362-f08b3285-fc7d-4751-88ea-ab79c2aa1a52.png)


Example, after:
![image](https://user-images.githubusercontent.com/642886/156792792-416c8c7c-e4ab-4359-a266-6b32f2e5450e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/94)
<!-- Reviewable:end -->
