### PR TITLE
secondary: add SummarizeErrors variadic method

### DIFF
--- a/secondary/secondary_test.go
+++ b/secondary/secondary_test.go
@@ -102,6 +102,33 @@ func TestCombineErrors(t *testing.T) {
 	}
 }
 
+// This test asserts SummarizeErrors output in terms of CombineErrors output.
+func TestSummarizeErrors(t *testing.T) {
+	tt := testutils.T{T: t}
+	err1 := errors.New("err1")
+	err2 := errors.New("err2")
+	chainWith2 := &werrFmt{err2, "chainWith2"}
+	chainWith1And2 := secondary.CombineErrors(chainWith2, err1)
+
+	testData := []struct {
+		args    []error
+		summary error
+	}{
+		{[]error{err1, err2}, secondary.CombineErrors(err1, err2)},
+		{[]error{err2, err1}, secondary.CombineErrors(err2, err1)},
+		{[]error{err1, err2, err1}, secondary.CombineErrors(err1, err2)},
+		{[]error{chainWith2, err2}, chainWith2},
+		{[]error{err2, chainWith2}, chainWith2},
+		{[]error{chainWith2, err1, err2}, secondary.CombineErrors(chainWith2, err1)},
+		{[]error{chainWith2, chainWith1And2, err1, err2}, chainWith1And2},
+	}
+
+	for _, test := range testData {
+		err := secondary.SummarizeErrors(test.args...)
+		tt.CheckDeepEqual(err, test.summary)
+	}
+}
+
 func TestFormat(t *testing.T) {
 	tt := testutils.T{t}
 

--- a/secondary_api.go
+++ b/secondary_api.go
@@ -40,3 +40,11 @@ func WithSecondaryError(err error, additionalErr error) error {
 func CombineErrors(err, otherErr error) error {
 	return secondary.CombineErrors(err, otherErr)
 }
+
+// SummarizeErrors reduces a collection of errors to a single
+// error with the rest as secondary errors, making an effort
+// at deduplication. Use when it's not clear, or not deterministic,
+// which of many errors will be the root cause.
+func SummarizeErrors(errs ...error) error {
+	return secondary.SummarizeErrors(errs...)
+}


### PR DESCRIPTION
I was recently debugging a workflow with lots
of async workers able to cancel each other,
so that by the time an error bubbled up it was
ambiguous where the longest stack would be
and whether there were errors in two places
because one wrapped the other or because of two
separate root errors. I felt like what would be
most convenient would be to smoosh everything
together rather than try to be too smart about it.

This PR implements SummarizeErrors, which is mainly
the generalization of CombineErrors over n errors.
If one argument is detectably already wrapping another,
the result will ignore the latter. If two errors are
distinct but both wrapping the same error, the result
will preserve that information.
Two errors are distinct if err1 != err2; there didn't
look to be much benefit in bringing in things like .Is
as we're really interested in identity, not equivalence.

This is an unsolicited spike; feel free to bikeshed details or reject out of hand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/96)
<!-- Reviewable:end -->
