### PR TITLE
Add Go 1.20 errors.Join support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/errors
 
-go 1.17
+go 1.20
 
 require (
 	github.com/cockroachdb/datadriven v1.0.2

--- a/join.go
+++ b/join.go
@@ -1,0 +1,63 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Join returns an error that wraps the given errors.
+// Any nil error values are discarded.
+// Join returns nil if errs contains no non-nil values.
+// The error formats as the concatenation of the strings obtained
+// by calling the Error method of each element of errs, with a newline
+// between each string.
+func Join(errs ...error) error {
+	n := 0
+	for _, err := range errs {
+		if err != nil {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	e := &joinError{
+		errs: make([]error, 0, n),
+	}
+	for _, err := range errs {
+		if err != nil {
+			e.errs = append(e.errs, err)
+		}
+	}
+	return e
+}
+
+type joinError struct {
+	errs []error
+}
+
+func (e *joinError) Error() string {
+	var b []byte
+	for i, err := range e.errs {
+		if i > 0 {
+			b = append(b, '\n')
+		}
+		b = append(b, err.Error()...)
+	}
+	return string(b)
+}
+
+func (e *joinError) Unwrap() []error {
+	return e.errs
+}
+
+func (e *joinError) Format(w fmt.State, verb rune) {
+	for i, err := range e.Unwrap() {
+		if i > 0 {
+			fmt.Fprint(w, "\n")
+		}
+		fmt.Fprintf(w, "[%d]:\n  ", i)
+		s := fmt.Sprintf(fmt.FormatString(w, verb), err)
+		s = strings.Join(strings.Split(s, "\n"), "\n  ")
+		fmt.Fprint(w, s)
+	}
+}


### PR DESCRIPTION
(**Edit knz**) Informs #99 and cockroachdb/cockroach#97799

(**Note: the work in this PR is important but not sufficient to handle the Go 1.20 changes - we need to extend the other components to properly support multierrors from other packages in network serialization/deserialization**)

All errors using `cockroachdb/errors`  that are combined using Go 1.20 std lib `errors.Join` will lose the stacktrace when you `fmt.Printf("%+v\n", err)` on the joined error. Also, without native `errors.Join` support, this library is not a drop in replacement for the Go 1.20 stdlib `errors` package.

This PR adds `errors.Join` from Go 1.20 stdlib, but with a `Format()` method so joined errors honor the format verbs. Joined errors are printed verbosely indexed in square brackets like `[0]`, to differentiate them from the parenthetical indexing `(0)` of wrapped errors.

```
[0]:
  (1) Another bad thing happened: Something went wrong
    -- Stack trace:
    | [...repeated from below...]
  Wraps: (2) Another bad thing happened: Something went wrong
  Wraps: (3) Something went wrong
    -- Stack trace:main.foo
    | 	_example/main.go:22
    | main.bar
    | 	_example/main.go:26
    | main.main
    | 	_example/main.go:36
    | runtime.main
    | 	/Users/steve/.asdf/installs/golang/1.20.2/go/src/runtime/proc.go:250
  Wraps: (4) Something went wrong
  Error types: (1) *errors.withStack (2) *errors.wrapper (3) *errors.withStack (4) main.ErrMyError
    -- Stack trace:main.main
    | 	_example/main.go:38
[1]:
  (1) Yet another bad thing happened: Something went wrong
    -- Stack trace:
    | [...repeated from below...]
  Wraps: (2) Yet another bad thing happened: Something went wrong
  Wraps: (3) Something went wrong
    -- Stack trace:main.foo
    | 	_example/main.go:22
    | main.baz
    | 	_example/main.go:31
    | main.main
    | 	_example/main.go:40
    | runtime.main
    | 	/Users/steve/.asdf/installs/golang/1.20.2/go/src/runtime/proc.go:250
  Wraps: (4) Something went wrong
  Error types: (1) *errors.withStack (2) *errors.wrapper (3) *errors.withStack (4) main.ErrMyError
    -- Stack trace:main.main
    | 	_example/main.go:40
```

This PR is not meant to be merged as is, and is more for discussion (and is hopefully helpful rather than just annoying 😬 ).

It currently leans on Go 1.20 std lib pkg fmt's new `func FormatString(State, int32) string` [fmt: add FormatString(State) string #51668](https://github.com/golang/go/issues/51668), rather than using the `cockroachdb/errors`  internal format forwarding. As a result, this current implementation depends on Go 1.20+.

It is likely that backwards compatibility with pre-Go 1.20 is desirable, so this `Format()` would need to be reworked to use this library's `errbase.Formatter` and `errbase.SafeFormatter` to avoid that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/106)
<!-- Reviewable:end -->
