### PR TITLE
Add `status.Errorf` to the gRPC Wrappers

### DIFF
--- a/grpc/status/status.go
+++ b/grpc/status/status.go
@@ -12,11 +12,15 @@ func Error(c codes.Code, msg string) error {
 }
 
 func Errorf(c codes.Code, format string, args ...interface{}) error {
-	return extgrpc.WrapWithGrpcCode(errors.Errorf(format, args...), c)
+	return extgrpc.WrapWithGrpcCode(errors.Newf(format, args...), c)
 }
 
 func WrapErr(c codes.Code, msg string, err error) error {
 	return extgrpc.WrapWithGrpcCode(errors.WrapWithDepth(1, err, msg), c)
+}
+
+func WrapErrf(c codes.Code, err error, format string, args ...interface{}) error {
+	return extgrpc.WrapWithGrpcCode(errors.WrapWithDepthf(1, err, format, args...), c)
 }
 
 func Code(err error) codes.Code {

--- a/grpc/status/status.go
+++ b/grpc/status/status.go
@@ -11,6 +11,10 @@ func Error(c codes.Code, msg string) error {
 	return extgrpc.WrapWithGrpcCode(errors.New(msg), c)
 }
 
+func Errorf(c codes.Code, format string, args ...interface{}) error {
+	return extgrpc.WrapWithGrpcCode(errors.Errorf(format, args...), c)
+}
+
 func WrapErr(c codes.Code, msg string, err error) error {
 	return extgrpc.WrapWithGrpcCode(errors.WrapWithDepth(1, err, msg), c)
 }


### PR DESCRIPTION
Mirrors the official grpc-go `status` package's `status.Errorf` defined [here](https://github.com/grpc/grpc-go/blob/master/status/status.go#L63).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/110)
<!-- Reviewable:end -->
