### PR TITLE
ci: update actions; remove unneded check for go version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,10 @@ jobs:
           - "1.20"
           - "1.21"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go (${{ matrix.go }}
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go }}
 
@@ -30,4 +30,4 @@ jobs:
       run: go test ./...
 
     - name: Tidy (${{ matrix.go }})
-      run: '[[ `go version` < "go version go1.15.10" ]] || go mod tidy'
+      run: go mod tidy


### PR DESCRIPTION
This PR:
- updates [actions/checkout](https://github.com/actions/checkout/tags) and [actions/setup-go](https://github.com/actions/setup-go/tags) to the latest.
- removes unnecessary Go version check when running `go mod tidy`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/124)
<!-- Reviewable:end -->
