### PR TITLE
Fix typos in comments

### DIFF
--- a/contexttags_api.go
+++ b/contexttags_api.go
@@ -24,7 +24,7 @@ import (
 // WithContextTags captures the k/v pairs stored in the context via the
 // `logtags` package and annotates them on the error.
 //
-// Only the stromg representation of values remains available. This is
+// Only the strong representation of values remains available. This is
 // because the library cannot guarantee that the underlying value is
 // preserved across the network. To avoid creating a stateful interface
 // (where the user code needs to know whether an error has traveled

--- a/errbase/format_error.go
+++ b/errbase/format_error.go
@@ -648,7 +648,7 @@ type state struct {
 
 	// entries collect the result of formatRecursive(). They are
 	// consumed by formatSingleLineOutput() and formatEntries() to
-	// procude the contents of finalBuf.
+	// produce the contents of finalBuf.
 	entries []formatEntry
 
 	// buf collects the details of the current error object at a given
@@ -928,7 +928,7 @@ func (s *safePrinter) enhanceArgs(args []interface{}) {
 			args[i] = redact.Safe(thisStack)
 			lastSeen = st
 		}
-		// In contrast with (*printer).enhanceArgs(), we dont use a
+		// In contrast with (*printer).enhanceArgs(), we don't use a
 		// special case for `error` here, because the redact package
 		// already helps us recursing into a safe print for
 		// error objects.

--- a/report/report.go
+++ b/report/report.go
@@ -38,7 +38,7 @@ import (
 // Title: (1) some prefix in bold (2) one line for a stack trace
 // (3) a single-line subtitle
 //
-// (4) the tags, as a tag soup (concatenated in a single paragrah,
+// (4) the tags, as a tag soup (concatenated in a single paragraph,
 // unsorted)
 //
 // (5) a "message"
@@ -66,7 +66,7 @@ import (
 // (3) the Value field of the 1st Exception object, if any, unwrapped as a single line
 // (4) the Tags field
 // (5) the Message field
-// (7) the Type field (same as (1) for 1st execption)
+// (7) the Type field (same as (1) for 1st exception)
 // (8) the Value field (same as (3) for 1st exception)
 // (9) the Stacktrace field (input to (2) on 1st exception)
 // (10) the other fields on the Event object
@@ -296,7 +296,7 @@ func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]
 	event.Message = longMsgBuf.String()
 	event.Exception = exceptions
 
-	// If there is no exception payload, synthetize one.
+	// If there is no exception payload, synthesize one.
 	if len(event.Exception) == 0 {
 		// We know we don't have a stack trace to extract line/function
 		// info from (if we had, we'd have an Exception payload at that

--- a/report_api.go
+++ b/report_api.go
@@ -32,7 +32,7 @@ import (
 // Title: (1) some prefix in bold (2) one line for a stack trace
 // (3) a single-line subtitle
 //
-// (4) the tags, as a tag soup (concatenated in a single paragrah,
+// (4) the tags, as a tag soup (concatenated in a single paragraph,
 // unsorted)
 //
 // (5) a "message"
@@ -57,7 +57,7 @@ import (
 // (3) the Value field of the 1st Exception object, if any, unwrapped as a single line
 // (4) the Tags field
 // (5) the Message field
-// (7) the Type field (same as (1) for 1st execption)
+// (7) the Type field (same as (1) for 1st exception)
 // (8) the Value field (same as (3) for 1st exception)
 // (9) the Stacktrace field (input to (2) on 1st exception)
 // (10) the other fields on the Event object


### PR DESCRIPTION
This PR fixes spelling mistakes in comments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/125)
<!-- Reviewable:end -->
