### PR TITLE
Replace deprecated io/ioutil package with os

### DIFF
--- a/fmttests/datadriven_test.go
+++ b/fmttests/datadriven_test.go
@@ -20,7 +20,6 @@ import (
 	goErr "errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"regexp"
@@ -385,7 +384,7 @@ func generateFiles() {
 		}
 		leafTests.WriteString("----\n\n")
 	}
-	ioutil.WriteFile(testPath+"/leaves", leafTests.Bytes(), 0666)
+	os.WriteFile(testPath+"/leaves", leafTests.Bytes(), 0666)
 
 	// Generate the "leaves-via-network" input file, which tests
 	// formatting for leaf-only error types after being brought over
@@ -405,7 +404,7 @@ func generateFiles() {
 		}
 		leafTests.WriteString("----\n\n")
 	}
-	ioutil.WriteFile(testPath+"/leaves-via-network", leafTests.Bytes(), 0666)
+	os.WriteFile(testPath+"/leaves-via-network", leafTests.Bytes(), 0666)
 
 	// Leaf types for which we want to test all wrappers:
 	wrapperLeafTypes := []string{"fmt", "goerr", "nofmt", "pkgerr", "newf"}
@@ -449,7 +448,7 @@ func generateFiles() {
 			}
 			wrapTests.WriteString("----\n\n")
 		}
-		ioutil.WriteFile(
+		os.WriteFile(
 			fmt.Sprintf(testPath+"/wrap-%s", leafName),
 			wrapTests.Bytes(), 0666)
 	}
@@ -490,7 +489,7 @@ func generateFiles() {
 			}
 			wrapTests.WriteString("----\n\n")
 		}
-		ioutil.WriteFile(
+		os.WriteFile(
 			fmt.Sprintf(testPath+"/wrap-%s-via-network", leafName),
 			wrapTests.Bytes(), 0666)
 	}

--- a/testutils/simplecheck.go
+++ b/testutils/simplecheck.go
@@ -17,7 +17,7 @@ package testutils
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -212,7 +212,7 @@ func fileContext(filename string, line, context int) ([][]byte, int) {
 	defer fileCacheLock.Unlock()
 	lines, ok := fileCache[filename]
 	if !ok {
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			// cache errors as nil slice: code below handles it correctly
 			// otherwise when missing the source or running as a different user, we try


### PR DESCRIPTION
The package [io/ioutil](https://pkg.go.dev/io/ioutil) has been deprecated since Go 1.19.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/126)
<!-- Reviewable:end -->
