### PR TITLE
Downgrade go version requirement to 1.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,24 @@ on:
     branches: [ master ]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - "1.18"
+          - "1.19"
+          - "1.20"
+    steps:
+      - uses: actions/checkout@v3
 
+      - name: Set up Go (${{ matrix.go }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Build (${{ matrix.go }})
+        run: go build ./...
   build-and-test:
     runs-on: ubuntu-latest
     strategy:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/errors
 
-go 1.20
+go 1.19
 
 require (
 	github.com/cockroachdb/datadriven v1.0.2


### PR DESCRIPTION
Previously, we had upgraded this library to be compatible with a number of features introduced in go 1.20. Our compatibility with the multi-cause errors does not depend on those features being available in the stdlib so the requirement in go.mod is being downgraded to 1.19.

This removes the need for an older compatibility branch released as version 1.10.1 of this library.

Go 1.20 features are only necessary to run tests. GitHub actions are adjusted to additionally test for a successful build on 1.19.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/127)
<!-- Reviewable:end -->
