### PR TITLE
Fix typos in comments and field names

### DIFF
--- a/contexttags/contexttags.go
+++ b/contexttags/contexttags.go
@@ -25,7 +25,7 @@ import (
 // WithContextTags captures the k/v pairs stored in the context via the
 // `logtags` package and annotates them on the error.
 //
-// Only the stromg representation of values remains available. This is
+// Only the strong representation of values remains available. This is
 // because the library cannot guarantee that the underlying value is
 // preserved across the network. To avoid creating a stateful interface
 // (where the user code needs to know whether an error has traveled

--- a/errutil/doc.go
+++ b/errutil/doc.go
@@ -14,6 +14,6 @@
 
 // Package errutil combines primitives from the library, the Go errors
 // package and github.com/pkg/errors. It aims to serve as drop-in
-// replacement to gitub.com/pkg/errors and replace the legacy
+// replacement to github.com/pkg/errors and replace the legacy
 // implementation of `pgerrors`.
 package errutil

--- a/exthttp/ext_http.go
+++ b/exthttp/ext_http.go
@@ -65,7 +65,7 @@ func (w *withHTTPCode) Unwrap() error { return w.cause }
 func (w *withHTTPCode) Format(s fmt.State, verb rune) { errors.FormatError(w, s, verb) }
 
 // SafeFormatter implements errors.SafeFormatter.
-// Note: see the documentat ion of errbase.SafeFormatter for details
+// Note: see the documentation of errbase.SafeFormatter for details
 // on how to implement this. In particular beware of not emitting
 // unsafe strings.
 func (w *withHTTPCode) SafeFormatError(p errors.Printer) (next error) {

--- a/fmttests/datadriven_test.go
+++ b/fmttests/datadriven_test.go
@@ -244,7 +244,7 @@ var wrapCommands = map[string]commandFn{
 	"assertwrap": func(err error, args []arg) error {
 		return errutil.NewAssertionErrorWithWrappedErrf(err, "assertmsg: %s", strfy(args))
 	},
-	// barirer is a simpler barrier
+	// barrier is a simpler barrier
 	"barrier": func(err error, _ []arg) error { return barriers.Handled(err) },
 	// domains are hidden annotations. Tested here for sentry reporting.
 	"domain": func(err error, _ []arg) error { return domains.WithDomain(err, "mydomain") },

--- a/markers/markers_test.go
+++ b/markers/markers_test.go
@@ -727,9 +727,9 @@ func (e *invalidError) Cause() error  { return e.emptyRef }
 func TestDelegateToIsMethod(t *testing.T) {
 	tt := testutils.T{T: t}
 
-	efoo := &errWithIs{msg: "foo", seecret: "foo"}
-	efoo2 := &errWithIs{msg: "foo", seecret: "bar"}
-	ebar := &errWithIs{msg: "bar", seecret: "foo"}
+	efoo := &errWithIs{msg: "foo", secret: "foo"}
+	efoo2 := &errWithIs{msg: "foo", secret: "bar"}
+	ebar := &errWithIs{msg: "bar", secret: "foo"}
 
 	tt.Check(markers.Is(efoo, efoo2))  // equality based on message
 	tt.Check(markers.Is(efoo, ebar))   // equality based on method
@@ -741,15 +741,15 @@ func TestDelegateToIsMethod(t *testing.T) {
 }
 
 type errWithIs struct {
-	msg     string
-	seecret string
+	msg    string
+	secret string
 }
 
 func (e *errWithIs) Error() string { return e.msg }
 
 func (e *errWithIs) Is(o error) bool {
 	if ex, ok := o.(*errWithIs); ok {
-		return e.seecret == ex.seecret
+		return e.secret == ex.secret
 	}
 	return false
 }


### PR DESCRIPTION
This PR corrects spelling mistakes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/128)
<!-- Reviewable:end -->
