### PR TITLE
IsAny() multi error support

### DIFF
--- a/markers/markers.go
+++ b/markers/markers.go
@@ -19,10 +19,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/cockroachdb/errors/errbase"
-	"github.com/cockroachdb/errors/errorspb"
 	"github.com/cockroachdb/redact"
 	"github.com/gogo/protobuf/proto"
+
+	"github.com/cockroachdb/errors/errbase"
+	"github.com/cockroachdb/errors/errorspb"
 )
 
 // Is determines whether one of the causes of the given error or any
@@ -176,6 +177,13 @@ func IsAny(err error, references ...error) bool {
 			// Compatibility with std go errors: if the error object itself
 			// implements Is(), try to use that.
 			if tryDelegateToIsMethod(c, refErr) {
+				return true
+			}
+		}
+
+		// Recursively try multi-error causes, if applicable.
+		for _, me := range errbase.UnwrapMulti(c) {
+			if IsAny(me, references...) {
 				return true
 			}
 		}

--- a/markers/markers_test.go
+++ b/markers/markers_test.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 	"testing"
 
+	pkgErr "github.com/pkg/errors"
+
 	"github.com/cockroachdb/errors/errbase"
 	"github.com/cockroachdb/errors/markers"
 	"github.com/cockroachdb/errors/testutils"
-	pkgErr "github.com/pkg/errors"
 )
 
 // This test demonstrates that Is() returns true if passed the same
@@ -361,6 +362,9 @@ func TestIsAny(t *testing.T) {
 	err2 := errors.New("world")
 	err3 := pkgErr.Wrap(err1, "world")
 	err4 := pkgErr.Wrap(err2, "universe")
+	err5 := errors.Join(err1, errors.New("gopher"))
+	err6 := errors.Join(errors.New("gopher"), err2)
+	err7 := errors.Join(err1, err2)
 	var nilErr error
 
 	tt.Check(markers.IsAny(err1, err1))
@@ -371,6 +375,11 @@ func TestIsAny(t *testing.T) {
 	tt.Check(markers.IsAny(err3, err2, nilErr, err1))
 	tt.Check(markers.IsAny(nilErr, err2, nilErr, err1))
 	tt.Check(!markers.IsAny(nilErr, err2, err1))
+	tt.Check(markers.IsAny(err5, err1))
+	tt.Check(markers.IsAny(err6, err2))
+	tt.Check(markers.IsAny(err7, err1))
+	tt.Check(markers.IsAny(err7, err2))
+	tt.Check(markers.IsAny(err7, err1, err2))
 }
 
 // This test demonstrates that two errors that are structurally


### PR DESCRIPTION
Hello! At the moment the following code will produce the result "no". I suggest a fix based on the code found in the original method `Is()`.
```golang
func main() {
	err := errors.Join(io.EOF, errors.New("gopher"))

	if errors.IsAny(err, io.EOF, net.ErrClosed) {
		fmt.Print("yes")
	} else {
		fmt.Print("no")
	}
}
```
