### PR TITLE
Correct example names for HasType and HasInterface

### DIFF
--- a/markers/example_has_type_test.go
+++ b/markers/example_has_type_test.go
@@ -26,7 +26,7 @@ type ExampleError struct{ msg string }
 
 func (e *ExampleError) Error() string { return e.msg }
 
-func ExampleIsType() {
+func ExampleHasType() {
 	base := &ExampleError{"world"}
 	err := errors.Wrap(base, "hello")
 	fmt.Println(markers.HasType(err, (*ExampleError)(nil)))
@@ -40,7 +40,7 @@ func ExampleIsType() {
 	// false
 }
 
-func ExampleIsInterface() {
+func ExampleHasInterface() {
 	base := &net.AddrError{
 		Addr: "ndn",
 		Err:  "ndn doesn't really exists :(",


### PR DESCRIPTION
This PR corrects the names of example functions to match the file name:

- `ExampleIsType` is renamed to `ExampleHasType` as it serves as an example for `markers.HasType`.
- `ExampleIsInterface` is renamed to `ExampleHasInterface` as it serves as an example for `markers.HasInterface`.
- `markers/example_is_type_test.go` is renamed to `markers/example_has_type_test.go`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/144)
<!-- Reviewable:end -->
