### PR TITLE
docs: remove * as it should be value

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ In short:
   exactly as follows:
 
   ```go
-  func (e *yourType) Format(s *fmt.State, verb rune) { errors.FormatError(e, s, verb) }
+  func (e *yourType) Format(s fmt.State, verb rune) { errors.FormatError(e, s, verb) }
   ```
 
   (If you do not provide this redirection for your own custom wrapper


### PR DESCRIPTION
The definition of the `Formatter` interface is below:

```
type Formatter interface {
	Format(f State, verb rune)
}
```

Therefore `yourType` should implement exactly the same signature.