### PR TITLE
chore: normalize Go version in go.mod to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/errors
 
-go 1.23.0
+go 1.23
 
 toolchain go1.23.8
 


### PR DESCRIPTION
The go directive should use only major and minor versions. go 1.23.0 is not valid - Go ignores the patch part, so it should be go 1.23.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/154)
<!-- Reviewable:end -->


