### PR TITLE
build: bump min Go version to 1.25, add 1.26 to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.23"
-          - "1.24"
+          - "1.25"
+          - "1.26"
     steps:
       - uses: actions/checkout@v3
 
@@ -29,8 +29,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.23"
-          - "1.24"
+          - "1.25"
+          - "1.26"
     steps:
     - uses: actions/checkout@v3
 

--- a/fmttests/datadriven_test.go
+++ b/fmttests/datadriven_test.go
@@ -105,7 +105,7 @@ var leafCommands = map[string]commandFn{
 	},
 
 	"unimplemented": func(_ error, args []arg) error {
-		return issuelink.UnimplementedErrorf(issuelink.IssueLink{IssueURL: "https://mysite", Detail: "issuedetails"}, strfy(args))
+		return issuelink.UnimplementedErrorf(issuelink.IssueLink{IssueURL: "https://mysite", Detail: "issuedetails"}, "%s", strfy(args))
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/cockroachdb/errors
 
-go 1.23.0
-
-toolchain go1.23.8
+go 1.25.0
 
 require (
 	github.com/cockroachdb/datadriven v1.0.2


### PR DESCRIPTION
- Bump minimum Go version in `go.mod` from 1.23 to 1.25
- Update CI matrix to test Go 1.25 and 1.26 (removing 1.23 and 1.24)
- Fix non-constant format string in `fmttests/datadriven_test.go` flagged by Go 1.26's vet checker

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/160)
<!-- Reviewable:end -->
