### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ An error *leaf* is an object that implements the `error` interface,
 but does not refer to another error via a `Unwrap()` or `Cause()`
 method.
 
-- `New(string) error`, `Newf(string, ...interface{}) error`, `Errorf(string, ...interface{}) error`: leaf errors with message
+- `New(string) error`, `Newf(string, ...any) error`, `Errorf(string, ...any) error`: leaf errors with message
   - **when to use: common error cases.**
   - what it does: also captures the stack trace at point of call and redacts the provided message for safe reporting.
   - how to access the detail: `Error()`, regular Go formatting. **Details in Sentry report.**
   - see also: Section [Error composition](#Error-composition-summary) below. `errors.NewWithDepth()` variants to customize at which call depth the stack trace is captured.
 
-- `AssertionFailedf(string, ...interface{}) error`, `NewAssertionFailureWithWrappedErrf(error, string, ...interface{}) error`: signals an assertion failure / programming error.
+- `AssertionFailedf(string, ...any) error`, `NewAssertionFailureWithWrappedErrf(error, string, ...any) error`: signals an assertion failure / programming error.
   - **when to use: when an invariant is violated; when an unreachable code path is reached.**
   - what it does: also captures the stack trace at point of call, redacts the provided strings for safe reporting, prepares a hint to inform a human user.
   - how to access the detail: `IsAssertionFailure()`/`HasAssertionFailure()`, format with `%+v`, Safe details included in Sentry reports.
@@ -143,7 +143,7 @@ they behave as no-ops in this case:
 return errors.Wrap(foo(), "foo")
 ```
 
-- `Wrap(error, string) error`, `Wrapf(error, string, ...interface{}) error`:
+- `Wrap(error, string) error`, `Wrapf(error, string, ...any) error`:
   - **when to use: on error return paths.**
   - what it does: combines `WithMessage()`, `WithStack()`, `WithSafeDetails()`.
   - how to access the details: `Error()`, regular Go formatting. **Details in Sentry report.**
@@ -198,22 +198,22 @@ return errors.Wrap(foo(), "foo")
   - how to access the details: format with `%+v`, `errors.GetSafeDetails()`, Sentry reports. The stack trace is considered safe for reporting.
   - see also: `WithStackDepth()` to customize the call depth at which the stack trace is captured.
 
-- `WithSafeDetails(error, string, ...interface{}) error`: safe details for reporting.
+- `WithSafeDetails(error, string, ...any) error`: safe details for reporting.
   - when to use: probably never. Use `errors.Wrap()`/`errors.Wrapf()` instead.
   - what it does: saves some strings for safe reporting.
   - how to access the detail: format with `%+v`, `errors.GetSafeDetails()`, Sentry report.
 
-- `WithMessage(error, string) error`, `WithMessagef(error, string, ...interface{}) error`: message prefix.
+- `WithMessage(error, string) error`, `WithMessagef(error, string, ...any) error`: message prefix.
   - when to use: probably never. Use `errors.Wrap()`/`errors.Wrapf()` instead.
   - what it does: adds a message prefix.
   - how to access the detail: `Error()`, regular Go formatting, Sentry Report.
 
-- `WithDetail(error, string) error`, `WithDetailf(error, string, ...interface{}) error`, user-facing detail with contextual information.
+- `WithDetail(error, string) error`, `WithDetailf(error, string, ...any) error`, user-facing detail with contextual information.
   - **when to use: need to embark a message string to output when the error is presented to a developer.**
   - what it does: captures detail strings.
   - how to access the detail: `errors.GetAllDetails()`, `errors.FlattenDetails()` (all details are preserved), format with `%+v`. Not included in Sentry reports.
 
-- `WithHint(error, string) error`, `WithHintf(error, string, ...interface{}) error`: user-facing detail with suggestion for action to take.
+- `WithHint(error, string) error`, `WithHintf(error, string, ...any) error`: user-facing detail with suggestion for action to take.
   - **when to use: need to embark a message string to output when the error is presented to an end user.**
   - what it does: captures hint strings.
   - how to access the detail: `errors.GetAllHints()`, `errors.FlattenHints()` (hints are de-duplicated), format with `%+v`. Not included in Sentry reports.
@@ -279,7 +279,7 @@ It is possible to opt additional in to Sentry reporting, using either of the fol
   - it also makes it available via `errors.GetSafeDetails()`/`GetAllSafeDetails()`.
   - the value 123 is also part of the main error message returned by `Error()`.
 
-- attach additional arbitrary strings with `errors.WithSafeDetails(error, string, ...interface{}) error` and
+- attach additional arbitrary strings with `errors.WithSafeDetails(error, string, ...any) error` and
   also use `errors.Safe()`.
   For example: `err = errors.WithSafeDetails(err, "additional data: %s", errors.Safe("hello"))`.
   - in this example, the string "hello" will be included in Sentry reports.
@@ -561,8 +561,8 @@ func Formattable(err error) fmt.Formatter
 // Identify errors.
 func Is(err, reference error) bool
 func IsAny(err error, references ...error) bool
-func If(err error, pred func(err error) (interface{}, bool)) (interface{}, bool)
-func As(err error, target interface{}) bool
+func If(err error, pred func(err error) (any, bool)) (any, bool)
+func As(err error, target any) bool
 
 // Encode/decode errors.
 type EncodedError // this is protobuf-encodable
@@ -589,7 +589,7 @@ type MultiCauseDecoder = func(ctx context.Context, causes []error, msgPrefix str
 func RegisterTypeMigration(previousPkgPath, previousTypeName string, newType error)
 
 // Sentry reports.
-func BuildSentryReport(err error) (*sentry.Event, map[string]interface{})
+func BuildSentryReport(err error) (*sentry.Event, map[string]any)
 func ReportError(err error) (string)
 
 // Stack trace captures.
@@ -604,10 +604,10 @@ func GetSafeDetails(err error) (payload SafeDetailPayload)
 
 // Obsolete APIs.
 type SafeMessager interface { ... }
-func Redact(r interface{}) string
+func Redact(r any) string
 
 // Aliases redact.Safe.
-func Safe(v interface{}) SafeMessager
+func Safe(v any) SafeMessager
 
 // Assertion failures.
 func HasAssertionFailure(err error) bool

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -41,7 +41,7 @@ func WithAssertionFailure(err error) error {
 // HasAssertionFailure returns true if the error or any of its causes
 // is an assertion failure annotation.
 func HasAssertionFailure(err error) bool {
-	_, ok := markers.If(err, func(err error) (v interface{}, ok bool) {
+	_, ok := markers.If(err, func(err error) (v any, ok bool) {
 		v, ok = err.(*withAssertionFailure)
 		return
 	})

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -38,7 +38,7 @@ func TestAssert(t *testing.T) {
 
 	tt.Check(assert.HasAssertionFailure(err))
 
-	if _, ok := markers.If(err, func(err error) (interface{}, bool) { return nil, assert.IsAssertionFailure(err) }); !ok {
+	if _, ok := markers.If(err, func(err error) (any, bool) { return nil, assert.IsAssertionFailure(err) }); !ok {
 		t.Error("woops")
 	}
 
@@ -51,7 +51,7 @@ func TestAssert(t *testing.T) {
 
 	tt.Check(assert.HasAssertionFailure(newErr))
 
-	if _, ok := markers.If(newErr, func(err error) (interface{}, bool) { return nil, assert.IsAssertionFailure(err) }); !ok {
+	if _, ok := markers.If(newErr, func(err error) (any, bool) { return nil, assert.IsAssertionFailure(err) }); !ok {
 		t.Error("woops")
 	}
 

--- a/barriers/barriers.go
+++ b/barriers/barriers.go
@@ -59,7 +59,7 @@ func HandledWithSafeMessage(err error, msg redact.RedactableString) error {
 
 // HandledWithMessagef is like HandledWithMessagef except the message
 // is formatted.
-func HandledWithMessagef(err error, format string, args ...interface{}) error {
+func HandledWithMessagef(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}

--- a/contexttags/contexttags.go
+++ b/contexttags/contexttags.go
@@ -100,7 +100,7 @@ func redactableTagsIterate(b *logtags.Buffer, fn func(i int, s redact.Redactable
 		k := t.Key()
 		v := t.Value()
 		eq := empty
-		var val interface{} = empty
+		var val any = empty
 		if v != nil {
 			if len(k) > 1 {
 				eq = "="

--- a/errbase/encode.go
+++ b/errbase/encode.go
@@ -102,12 +102,12 @@ func encodeLeaf(ctx context.Context, err error, causes []error) EncodedError {
 
 // warningFn can be overridden with a suitable logging function using
 // SetWarningFn() below.
-var warningFn = func(_ context.Context, format string, args ...interface{}) {
+var warningFn = func(_ context.Context, format string, args ...any) {
 	log.Printf(format, args...)
 }
 
 // SetWarningFn enables configuration of the warning function.
-func SetWarningFn(fn func(context.Context, string, ...interface{})) {
+func SetWarningFn(fn func(context.Context, string, ...any)) {
 	warningFn = fn
 }
 

--- a/errbase/format_error.go
+++ b/errbase/format_error.go
@@ -871,17 +871,17 @@ func (s *printer) Detail() bool {
 	return ((*state)(s)).detail()
 }
 
-func (s *printer) Print(args ...interface{}) {
+func (s *printer) Print(args ...any) {
 	s.enhanceArgs(args)
 	fmt.Fprint((*state)(s), args...)
 }
 
-func (s *printer) Printf(format string, args ...interface{}) {
+func (s *printer) Printf(format string, args ...any) {
 	s.enhanceArgs(args)
 	fmt.Fprintf((*state)(s), format, args...)
 }
 
-func (s *printer) enhanceArgs(args []interface{}) {
+func (s *printer) enhanceArgs(args []any) {
 	prevStack := s.lastStack
 	lastSeen := prevStack
 	for i := range args {
@@ -908,17 +908,17 @@ func (s *safePrinter) Detail() bool {
 	return ((*state)(s)).detail()
 }
 
-func (s *safePrinter) Print(args ...interface{}) {
+func (s *safePrinter) Print(args ...any) {
 	s.enhanceArgs(args)
 	redact.Fprint((*state)(s), args...)
 }
 
-func (s *safePrinter) Printf(format string, args ...interface{}) {
+func (s *safePrinter) Printf(format string, args ...any) {
 	s.enhanceArgs(args)
 	redact.Fprintf((*state)(s), format, args...)
 }
 
-func (s *safePrinter) enhanceArgs(args []interface{}) {
+func (s *safePrinter) enhanceArgs(args []any) {
 	prevStack := s.lastStack
 	lastSeen := prevStack
 	for i := range args {

--- a/errbase/formatter.go
+++ b/errbase/formatter.go
@@ -85,10 +85,10 @@ type SafeFormatter interface {
 // typically provide their own implementations.
 type Printer interface {
 	// Print appends args to the message output.
-	Print(args ...interface{})
+	Print(args ...any)
 
 	// Printf writes a formatted string.
-	Printf(format string, args ...interface{})
+	Printf(format string, args ...any)
 
 	// Detail reports whether error detail is requested.
 	// After the first call to Detail, all text written to the Printer

--- a/errbase/stack_format_test.go
+++ b/errbase/stack_format_test.go
@@ -99,7 +99,7 @@ Error types: (1) *errors.withStack (2) *errors.fundamental`)
 	})
 }
 
-func fmtClean(x interface{}) string {
+func fmtClean(x any) string {
 	spv := fmt.Sprintf("%+v", x)
 	spv = fileref.ReplaceAllString(spv, "<path>:<lineno>")
 	spv = strings.ReplaceAll(spv, "\t", "<tab>")

--- a/errbase_api.go
+++ b/errbase_api.go
@@ -185,7 +185,7 @@ func RegisterMultiCauseEncoder(typeName TypeKey, encoder MultiCauseEncoder) {
 type MultiCauseEncoder = errbase.MultiCauseEncoder
 
 // SetWarningFn enables configuration of the warning function.
-func SetWarningFn(fn func(context.Context, string, ...interface{})) { errbase.SetWarningFn(fn) }
+func SetWarningFn(fn func(context.Context, string, ...any)) { errbase.SetWarningFn(fn) }
 
 // A Formatter formats error messages.
 //

--- a/errutil/as.go
+++ b/errutil/as.go
@@ -24,7 +24,7 @@ import (
 // As finds the first error in err's chain that matches the type to which target
 // points, and if so, sets the target to its value and returns true. An error
 // matches a type if it is assignable to the target type, or if it has a method
-// As(interface{}) bool such that As(target) returns true. As will panic if target
+// As(any) bool such that As(target) returns true. As will panic if target
 // is not a non-nil pointer to a type which implements error or is of interface type.
 //
 // The As method should set the target to its value and return true if err
@@ -33,7 +33,7 @@ import (
 // Note: this implementation differs from that of xerrors as follows:
 // - it also supports recursing through causes with Cause().
 // - if it detects an API use error, its panic object is a valid error.
-func As(err error, target interface{}) bool {
+func As(err error, target any) bool {
 	if target == nil {
 		panic(AssertionFailedf("errors.As: target cannot be nil"))
 	}
@@ -55,7 +55,7 @@ func As(err error, target interface{}) bool {
 			val.Elem().Set(reflect.ValueOf(c))
 			return true
 		}
-		if x, ok := c.(interface{ As(interface{}) bool }); ok && x.As(target) {
+		if x, ok := c.(interface{ As(any) bool }); ok && x.As(target) {
 			return true
 		}
 

--- a/errutil/assertions.go
+++ b/errutil/assertions.go
@@ -26,14 +26,14 @@ import (
 // - via `errors.GetSafeDetails()`, shows redacted strings.
 // - when formatting with `%+v`.
 // - in Sentry reports.
-func AssertionFailedf(format string, args ...interface{}) error {
+func AssertionFailedf(format string, args ...any) error {
 	return AssertionFailedWithDepthf(1, format, args...)
 }
 
 // AssertionFailedWithDepthf creates an internal error
 // with a stack trace collected at the specified depth.
 // See the doc of `AssertionFailedf()` for more details.
-func AssertionFailedWithDepthf(depth int, format string, args ...interface{}) error {
+func AssertionFailedWithDepthf(depth int, format string, args ...any) error {
 	err := NewWithDepthf(1+depth, format, args...)
 	err = assert.WithAssertionFailure(err)
 	return err
@@ -62,7 +62,7 @@ func HandleAsAssertionFailureDepth(depth int, origErr error) error {
 // context of the caller are preserved. The original error is not
 // visible as cause any more. The original error message is preserved.
 // See the doc of `AssertionFailedf()` for more details.
-func NewAssertionErrorWithWrappedErrf(origErr error, format string, args ...interface{}) error {
+func NewAssertionErrorWithWrappedErrf(origErr error, format string, args ...any) error {
 	return NewAssertionErrorWithWrappedErrDepthf(1, origErr, format, args...)
 }
 
@@ -71,7 +71,7 @@ func NewAssertionErrorWithWrappedErrf(origErr error, format string, args ...inte
 // stack is captured can be specified.
 // See the doc of `AssertionFailedf()` for more details.
 func NewAssertionErrorWithWrappedErrDepthf(
-	depth int, origErr error, format string, args ...interface{},
+	depth int, origErr error, format string, args ...any,
 ) error {
 	err := barriers.Handled(origErr)
 	err = WrapWithDepthf(depth+1, err, format, args...)

--- a/errutil/message.go
+++ b/errutil/message.go
@@ -34,7 +34,7 @@ func WithMessage(err error, message string) error {
 // If err is nil, WithMessagef returns nil.
 // The message is formatted as per redact.Sprintf,
 // to separate safe and unsafe strings for Sentry reporting.
-func WithMessagef(err error, format string, args ...interface{}) error {
+func WithMessagef(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}

--- a/errutil/utilities.go
+++ b/errutil/utilities.go
@@ -56,14 +56,14 @@ func NewWithDepth(depth int, msg string) error {
 // strings that may contain PII information.
 //
 // See the doc of `New()` for more details.
-func Newf(format string, args ...interface{}) error {
+func Newf(format string, args ...any) error {
 	return NewWithDepthf(1, format, args...)
 }
 
 // NewWithDepthf is like Newf() except the depth to capture the stack
 // trace is configurable.
 // See the doc of `New()` for more details.
-func NewWithDepthf(depth int, format string, args ...interface{}) error {
+func NewWithDepthf(depth int, format string, args ...any) error {
 	// If there's the verb %w in here, shortcut to fmt.Errorf()
 	// and store the safe details as extra payload. That's
 	// because we don't want to re-implement the error wrapping
@@ -133,14 +133,14 @@ func WrapWithDepth(depth int, err error, msg string) error {
 // - everything when formatting with `%+v`.
 // - stack trace, format, and redacted details via `errors.GetSafeDetails()`.
 // - stack trace, format, and redacted details in Sentry reports.
-func Wrapf(err error, format string, args ...interface{}) error {
+func Wrapf(err error, format string, args ...any) error {
 	return WrapWithDepthf(1, err, format, args...)
 }
 
 // WrapWithDepthf is like Wrapf except the depth to capture the stack
 // trace is configurable.
 // The the doc of `Wrapf()` for more details.
-func WrapWithDepthf(depth int, err error, format string, args ...interface{}) error {
+func WrapWithDepthf(depth int, err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}

--- a/errutil_api.go
+++ b/errutil_api.go
@@ -49,17 +49,17 @@ func NewWithDepth(depth int, msg string) error { return errutil.NewWithDepth(dep
 // strings that may contain PII information.
 //
 // See the doc of `New()` for more details.
-func Newf(format string, args ...interface{}) error { return errutil.NewWithDepthf(1, format, args...) }
+func Newf(format string, args ...any) error { return errutil.NewWithDepthf(1, format, args...) }
 
 // NewWithDepthf is like Newf() except the depth to capture the stack
 // trace is configurable.
 // See the doc of `New()` for more details.
-func NewWithDepthf(depth int, format string, args ...interface{}) error {
+func NewWithDepthf(depth int, format string, args ...any) error {
 	return errutil.NewWithDepthf(depth+1, format, args...)
 }
 
 // Errorf aliases Newf().
-func Errorf(format string, args ...interface{}) error {
+func Errorf(format string, args ...any) error {
 	return errutil.NewWithDepthf(1, format, args...)
 }
 
@@ -87,7 +87,7 @@ func WithMessage(err error, msg string) error { return errutil.WithMessage(err, 
 // If err is nil, WithMessagef returns nil.
 // The message is formatted as per redact.Sprintf,
 // to separate safe and unsafe strings for Sentry reporting.
-func WithMessagef(err error, format string, args ...interface{}) error {
+func WithMessagef(err error, format string, args ...any) error {
 	return errutil.WithMessagef(err, format, args...)
 }
 
@@ -127,14 +127,14 @@ func WrapWithDepth(depth int, err error, msg string) error {
 // - everything when formatting with `%+v`.
 // - stack trace, format, and redacted details via `errors.GetSafeDetails()`.
 // - stack trace, format, and redacted details in Sentry reports.
-func Wrapf(err error, format string, args ...interface{}) error {
+func Wrapf(err error, format string, args ...any) error {
 	return errutil.WrapWithDepthf(1, err, format, args...)
 }
 
 // WrapWithDepthf is like Wrapf except the depth to capture the stack
 // trace is configurable.
 // The the doc of `Wrapf()` for more details.
-func WrapWithDepthf(depth int, err error, format string, args ...interface{}) error {
+func WrapWithDepthf(depth int, err error, format string, args ...any) error {
 	return errutil.WrapWithDepthf(depth+1, err, format, args...)
 }
 
@@ -144,14 +144,14 @@ func WrapWithDepthf(depth int, err error, format string, args ...interface{}) er
 // - via `errors.GetSafeDetails()`, shows redacted strings.
 // - when formatting with `%+v`.
 // - in Sentry reports.
-func AssertionFailedf(format string, args ...interface{}) error {
+func AssertionFailedf(format string, args ...any) error {
 	return errutil.AssertionFailedWithDepthf(1, format, args...)
 }
 
 // AssertionFailedWithDepthf creates an internal error
 // with a stack trace collected at the specified depth.
 // See the doc of `AssertionFailedf()` for more details.
-func AssertionFailedWithDepthf(depth int, format string, args ...interface{}) error {
+func AssertionFailedWithDepthf(depth int, format string, args ...any) error {
 	return errutil.AssertionFailedWithDepthf(depth+1, format, args...)
 }
 
@@ -160,7 +160,7 @@ func AssertionFailedWithDepthf(depth int, format string, args ...interface{}) er
 // context of the caller are preserved. The original error is not
 // visible as cause any more. The original error message is preserved.
 // See the doc of `AssertionFailedf()` for more details.
-func NewAssertionErrorWithWrappedErrf(origErr error, format string, args ...interface{}) error {
+func NewAssertionErrorWithWrappedErrf(origErr error, format string, args ...any) error {
 	return errutil.NewAssertionErrorWithWrappedErrDepthf(1, origErr, format, args...)
 }
 
@@ -182,7 +182,7 @@ func HandleAsAssertionFailureDepth(depth int, origErr error) error {
 // As finds the first error in err's chain that matches the type to which target
 // points, and if so, sets the target to its value and returns true. An error
 // matches a type if it is assignable to the target type, or if it has a method
-// As(interface{}) bool such that As(target) returns true. As will panic if target
+// As(any) bool such that As(target) returns true. As will panic if target
 // is not a non-nil pointer to a type which implements error or is of interface type.
 //
 // The As method should set the target to its value and return true if err
@@ -191,7 +191,7 @@ func HandleAsAssertionFailureDepth(depth int, origErr error) error {
 // Note: this implementation differs from that of xerrors as follows:
 // - it also supports recursing through causes with Cause().
 // - if it detects an API use error, its panic object is a valid error.
-func As(err error, target interface{}) bool { return errutil.As(err, target) }
+func As(err error, target any) bool { return errutil.As(err, target) }
 
 // Join returns an error that wraps the given errors.
 // Any nil error values are discarded.

--- a/extgrpc/ext_grpc.go
+++ b/extgrpc/ext_grpc.go
@@ -73,7 +73,7 @@ func GetGrpcCode(err error) codes.Code {
 	if err == nil {
 		return codes.OK
 	}
-	if v, ok := markers.If(err, func(err error) (interface{}, bool) {
+	if v, ok := markers.If(err, func(err error) (any, bool) {
 		if w, ok := err.(*withGrpcCode); ok {
 			return w.code, true
 		}

--- a/extgrpc/ext_grpc_test.go
+++ b/extgrpc/ext_grpc_test.go
@@ -83,7 +83,7 @@ func (p *dummyProto) ProtoMessage()  {}
 type statusIface interface {
 	Code() codes.Code
 	Message() string
-	Details() []interface{}
+	Details() []any
 	Err() error
 }
 
@@ -92,7 +92,7 @@ func TestEncodeDecodeStatus(t *testing.T) {
 		desc          string
 		makeStatus    func(*testing.T, codes.Code, string, []proto.Message) statusIface
 		fromError     func(err error) statusIface
-		expectDetails []interface{} // nil elements signify errors
+		expectDetails []any // nil elements signify errors
 	}{
 		{
 			desc: "gogo status",
@@ -104,7 +104,7 @@ func TestEncodeDecodeStatus(t *testing.T) {
 			fromError: func(err error) statusIface {
 				return gogostatus.Convert(err)
 			},
-			expectDetails: []interface{}{
+			expectDetails: []any{
 				nil, // Protobuf decode fails
 				&errorspb.StringsPayload{Details: []string{"foo", "bar"}}, // gogoproto succeeds
 				nil, // dummy decode fails
@@ -124,10 +124,10 @@ func TestEncodeDecodeStatus(t *testing.T) {
 			fromError: func(err error) statusIface {
 				return grpcstatus.Convert(err)
 			},
-			expectDetails: []interface{}{
+			expectDetails: []any{
 				// Protobuf succeeds
-				func() interface{} {
-					var st interface{} = grpcstatus.New(codes.Internal, "status").Proto()
+				func() any {
+					var st any = grpcstatus.New(codes.Internal, "status").Proto()
 					res := reflect.New(reflect.TypeOf(st).Elem()).Interface()
 					copyPublicFields(res, st)
 					return res
@@ -218,7 +218,7 @@ func TestEncodeDecodeStatus(t *testing.T) {
 	}
 }
 
-func copyPublicFields(dst, src interface{}) {
+func copyPublicFields(dst, src any) {
 	srcval := reflect.Indirect(reflect.ValueOf(src))
 	dstval := reflect.Indirect(reflect.ValueOf(dst))
 	typ := srcval.Type()

--- a/exthttp/ext_http.go
+++ b/exthttp/ext_http.go
@@ -43,7 +43,7 @@ func WrapWithHTTPCode(err error, code int) error {
 
 // GetHTTPCode retrieves the HTTP code from a stack of causes.
 func GetHTTPCode(err error, defaultCode int) int {
-	if v, ok := markers.If(err, func(err error) (interface{}, bool) {
+	if v, ok := markers.If(err, func(err error) (any, bool) {
 		if w, ok := err.(*withHTTPCode); ok {
 			return w.code, true
 		}

--- a/fmttests/datadriven_test.go
+++ b/fmttests/datadriven_test.go
@@ -602,7 +602,7 @@ func TestDatadriven(t *testing.T) {
 
 				// Result buffer.
 				var buf bytes.Buffer
-				reportIrregular := func(format string, args ...interface{}) {
+				reportIrregular := func(format string, args ...any) {
 					s := fmt.Sprintf(format, args...)
 					fmt.Fprint(&buf, s)
 					if accepted(s) {

--- a/grpc/middleware/client.go
+++ b/grpc/middleware/client.go
@@ -12,8 +12,8 @@ import (
 func UnaryClientInterceptor(
 	ctx context.Context,
 	method string,
-	req interface{},
-	reply interface{},
+	req any,
+	reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,

--- a/grpc/middleware/server.go
+++ b/grpc/middleware/server.go
@@ -12,10 +12,10 @@ import (
 
 func UnaryServerInterceptor(
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (interface{}, error) {
+) (any, error) {
 	resp, err := handler(ctx, req)
 	if err == nil {
 		return resp, err

--- a/grpc/status/status.go
+++ b/grpc/status/status.go
@@ -11,7 +11,7 @@ func Error(c codes.Code, msg string) error {
 	return extgrpc.WrapWithGrpcCode(errors.New(msg), c)
 }
 
-func Errorf(c codes.Code, format string, args ...interface{}) error {
+func Errorf(c codes.Code, format string, args ...any) error {
 	return extgrpc.WrapWithGrpcCode(errors.Newf(format, args...), c)
 }
 
@@ -19,7 +19,7 @@ func WrapErr(c codes.Code, msg string, err error) error {
 	return extgrpc.WrapWithGrpcCode(errors.WrapWithDepth(1, err, msg), c)
 }
 
-func WrapErrf(c codes.Code, err error, format string, args ...interface{}) error {
+func WrapErrf(c codes.Code, err error, format string, args ...any) error {
 	return extgrpc.WrapWithGrpcCode(errors.WrapWithDepthf(1, err, format, args...), c)
 }
 

--- a/hintdetail/hintdetail.go
+++ b/hintdetail/hintdetail.go
@@ -40,7 +40,7 @@ func WithHint(err error, msg string) error {
 }
 
 // WithHintf is a helper that formats the hint.
-func WithHintf(err error, format string, args ...interface{}) error {
+func WithHintf(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}
@@ -117,7 +117,7 @@ func WithDetail(err error, msg string) error {
 }
 
 // WithDetailf is a helper that formats the detail string.
-func WithDetailf(err error, format string, args ...interface{}) error {
+func WithDetailf(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}

--- a/hintdetail_api.go
+++ b/hintdetail_api.go
@@ -39,7 +39,7 @@ func WithHint(err error, msg string) error { return hintdetail.WithHint(err, msg
 
 // WithHintf is a helper that formats the hint.
 // See the documentation of WithHint() for details.
-func WithHintf(err error, format string, args ...interface{}) error {
+func WithHintf(err error, format string, args ...any) error {
 	return hintdetail.WithHintf(err, format, args...)
 }
 
@@ -59,7 +59,7 @@ func WithDetail(err error, msg string) error { return hintdetail.WithDetail(err,
 
 // WithDetailf is a helper that formats the detail string.
 // See the documentation of WithDetail() for details.
-func WithDetailf(err error, format string, args ...interface{}) error {
+func WithDetailf(err error, format string, args ...any) error {
 	return hintdetail.WithDetailf(err, format, args...)
 }
 

--- a/issuelink/issuelink.go
+++ b/issuelink/issuelink.go
@@ -42,7 +42,7 @@ func WithIssueLink(err error, issue IssueLink) error {
 // HasIssueLink returns true iff the error or one of its
 // causes has a linked issue payload.
 func HasIssueLink(err error) bool {
-	_, ok := markers.If(err, func(err error) (v interface{}, ok bool) {
+	_, ok := markers.If(err, func(err error) (v any, ok bool) {
 		v, ok = err.(*withIssueLink)
 		return
 	})
@@ -81,7 +81,7 @@ func UnimplementedError(issueLink IssueLink, msg string) error {
 
 // UnimplementedErrorf creates a new leaf error that indicates that
 // some feature was not (yet) implemented. The message is formatted.
-func UnimplementedErrorf(issueLink IssueLink, format string, args ...interface{}) error {
+func UnimplementedErrorf(issueLink IssueLink, format string, args ...any) error {
 	return &unimplementedError{IssueLink: issueLink, msg: fmt.Sprintf(format, args...)}
 }
 

--- a/issuelink/issuelink_test.go
+++ b/issuelink/issuelink_test.go
@@ -47,7 +47,7 @@ func TestIssueLink(t *testing.T) {
 		tt.CheckStringEqual(err.Error(), "hello: world")
 
 		tt.Check(issuelink.HasIssueLink(err))
-		if _, ok := markers.If(err, func(err error) (interface{}, bool) { return nil, issuelink.IsIssueLink(err) }); !ok {
+		if _, ok := markers.If(err, func(err error) (any, bool) { return nil, issuelink.IsIssueLink(err) }); !ok {
 			t.Error("woops")
 		}
 

--- a/issuelink/unimplemented_test.go
+++ b/issuelink/unimplemented_test.go
@@ -37,7 +37,7 @@ func TestUnimplementedError(t *testing.T) {
 	theTest := func(tt testutils.T, err error) {
 		tt.Check(issuelink.HasUnimplementedError(err))
 		tt.Check(issuelink.IsUnimplementedError(errbase.UnwrapAll(err)))
-		if _, ok := markers.If(err, func(err error) (interface{}, bool) { return nil, issuelink.IsUnimplementedError(err) }); !ok {
+		if _, ok := markers.If(err, func(err error) (any, bool) { return nil, issuelink.IsUnimplementedError(err) }); !ok {
 			t.Error("woops")
 		}
 

--- a/issuelink_api.go
+++ b/issuelink_api.go
@@ -46,7 +46,7 @@ func UnimplementedError(issueLink IssueLink, msg string) error {
 
 // UnimplementedErrorf creates a new leaf error that indicates that
 // some feature was not (yet) implemented. The message is formatted.
-func UnimplementedErrorf(issueLink IssueLink, format string, args ...interface{}) error {
+func UnimplementedErrorf(issueLink IssueLink, format string, args ...any) error {
 	return issuelink.UnimplementedErrorf(issueLink, format, args...)
 }
 

--- a/markers/markers.go
+++ b/markers/markers.go
@@ -115,7 +115,7 @@ func tryDelegateToIsMethod(err, reference error) bool {
 // matches that of referenceType.
 func HasType(err error, referenceType error) bool {
 	typ := reflect.TypeOf(referenceType)
-	_, isType := If(err, func(err error) (interface{}, bool) {
+	_, isType := If(err, func(err error) (any, bool) {
 		return nil, reflect.TypeOf(err) == typ
 	})
 	return isType
@@ -125,15 +125,15 @@ func HasType(err error, referenceType error) bool {
 // interface pointed to by referenceInterface. The type of referenceInterface
 // must be a pointer to an interface type. If referenceInterface is not a
 // pointer to an interface, this function will panic.
-func HasInterface(err error, referenceInterface interface{}) bool {
+func HasInterface(err error, referenceInterface any) bool {
 	iface := getInterfaceType("HasInterface", referenceInterface)
-	_, isType := If(err, func(err error) (interface{}, bool) {
+	_, isType := If(err, func(err error) (any, bool) {
 		return nil, reflect.TypeOf(err).Implements(iface)
 	})
 	return isType
 }
 
-func getInterfaceType(context string, referenceInterface interface{}) reflect.Type {
+func getInterfaceType(context string, referenceInterface any) reflect.Type {
 	typ := reflect.TypeOf(referenceInterface)
 	if typ == nil || typ.Kind() != reflect.Ptr || typ.Elem().Kind() != reflect.Interface {
 		panic(fmt.Errorf("errors.%s: referenceInterface must be a pointer to an interface, "+
@@ -148,7 +148,7 @@ func getInterfaceType(context string, referenceInterface interface{}) reflect.Ty
 // Note: if any of the error types has been migrated from a previous
 // package location or a different type, ensure that
 // RegisterTypeMigration() was called prior to If().
-func If(err error, pred func(err error) (interface{}, bool)) (interface{}, bool) {
+func If(err error, pred func(err error) (any, bool)) (any, bool) {
 	for c := err; c != nil; c = errbase.UnwrapOnce(c) {
 		if v, ok := pred(c); ok {
 			return v, ok

--- a/markers_api.go
+++ b/markers_api.go
@@ -42,7 +42,7 @@ func HasType(err, referenceType error) bool { return markers.HasType(err, refere
 // interface pointed to by referenceInterface. The type of referenceInterface
 // must be a pointer to an interface type. If referenceInterface is not a
 // pointer to an interface, this function will panic.
-func HasInterface(err error, referenceInterface interface{}) bool {
+func HasInterface(err error, referenceInterface any) bool {
 	return markers.HasInterface(err, referenceInterface)
 }
 
@@ -52,7 +52,7 @@ func HasInterface(err error, referenceInterface interface{}) bool {
 // Note: if any of the error types has been migrated from a previous
 // package location or a different type, ensure that
 // RegisterTypeMigration() was called prior to If().
-func If(err error, pred func(err error) (interface{}, bool)) (interface{}, bool) {
+func If(err error, pred func(err error) (any, bool)) (any, bool) {
 	return markers.If(err, pred)
 }
 

--- a/oserror/oserror.go
+++ b/oserror/oserror.go
@@ -113,7 +113,7 @@ func IsNotExist(err error) bool {
 func IsTimeout(err error) bool {
 	// os.IsTimeout() cannot peek through Unwrap. We need errors.If()
 	// for that.
-	_, ok := errors.If(err, func(err error) (interface{}, bool) {
+	_, ok := errors.If(err, func(err error) (any, bool) {
 		return nil, os.IsTimeout(err)
 	})
 	return ok

--- a/report/report.go
+++ b/report/report.go
@@ -97,7 +97,7 @@ import (
 // is included in the Sentry report. This does not affect error types
 // provided by the library, but could impact error types defined by
 // 3rd parties. This limitation may be lifted in a later version.
-func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]interface{}) {
+func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]any) {
 	if err == nil {
 		// No error: do nothing.
 		return
@@ -144,7 +144,7 @@ func BuildSentryReport(err error) (event *sentry.Event, extraDetails map[string]
 	sep := ""
 
 	// extras will become the per-layer "Additional data" fields.
-	extras := make(map[string]interface{})
+	extras := make(map[string]any)
 
 	// extraNum counts the number of "Additional data" payloads and is
 	// used to generate the cross-reference counters in the Message

--- a/report_api.go
+++ b/report_api.go
@@ -87,7 +87,7 @@ import (
 // provided by the library, but could impact error types defined by
 // 3rd parties. This limitation may be lifted in a later version.
 //
-func BuildSentryReport(err error) (*sentry.Event, map[string]interface{}) {
+func BuildSentryReport(err error) (*sentry.Event, map[string]any) {
 	return report.BuildSentryReport(err)
 }
 

--- a/safedetails/redact.go
+++ b/safedetails/redact.go
@@ -20,6 +20,6 @@ import "github.com/cockroachdb/redact"
 // anonymized reporting.
 //
 // NB: this interface is obsolete. Use redact.Sprint() directly.
-func Redact(r interface{}) string {
+func Redact(r any) string {
 	return redact.Sprint(r).Redact().StripMarkers()
 }

--- a/safedetails/redact_test.go
+++ b/safedetails/redact_test.go
@@ -35,7 +35,7 @@ func TestRedact(t *testing.T) {
 	rm := string(redact.RedactableBytes(redact.RedactedMarker()).StripMarkers())
 
 	testData := []struct {
-		obj      interface{}
+		obj      any
 		expected string
 	}{
 		// Redacting non-error values.
@@ -121,7 +121,7 @@ func makeTypeAssertionErr() (result runtime.Error) {
 		e := recover()
 		result = e.(runtime.Error)
 	}()
-	var x interface{}
+	var x any
 	_ = x.(int)
 	return nil
 }

--- a/safedetails/safedetails.go
+++ b/safedetails/safedetails.go
@@ -33,7 +33,7 @@ import (
 // - via `errors.GetSafeDetails()`
 // - when formatting with `%+v`.
 // - in Sentry reports.
-func WithSafeDetails(err error, format string, args ...interface{}) error {
+func WithSafeDetails(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}
@@ -59,6 +59,6 @@ type SafeMessager = redact.SafeMessager
 // strings in error objects and reports.
 //
 // NB: this is obsolete. Use redact.Safe instead.
-func Safe(v interface{}) redact.SafeValue {
+func Safe(v any) redact.SafeValue {
 	return redact.Safe(v)
 }

--- a/safedetails_api.go
+++ b/safedetails_api.go
@@ -32,7 +32,7 @@ import (
 // - via `errors.GetSafeDetails()`
 // - when formatting with `%+v`.
 // - in Sentry reports.
-func WithSafeDetails(err error, format string, args ...interface{}) error {
+func WithSafeDetails(err error, format string, args ...any) error {
 	return safedetails.WithSafeDetails(err, format, args...)
 }
 
@@ -47,10 +47,10 @@ type SafeMessager = redact.SafeMessager
 // strings in error objects and reports.
 //
 // NB: this is obsolete. Use redact.Safe instead.
-func Safe(v interface{}) redact.SafeValue { return safedetails.Safe(v) }
+func Safe(v any) redact.SafeValue { return safedetails.Safe(v) }
 
 // Redact returns a redacted version of the supplied item that is safe to use in
 // anonymized reporting.
 //
 // NB: this interface is obsolete. Use redact.Sprint() directly.
-func Redact(r interface{}) string { return safedetails.Redact(r) }
+func Redact(r any) string { return safedetails.Redact(r) }

--- a/testutils/simplecheck.go
+++ b/testutils/simplecheck.go
@@ -92,7 +92,7 @@ func (t *T) Assert(cond bool) {
 }
 
 // AssertEqual asserts that the value is equal to some reference.
-func (t *T) AssertEqual(val, ref interface{}) {
+func (t *T) AssertEqual(val, ref any) {
 	t.Helper()
 	if val != ref {
 		t.failWithf(true, "assertion failed: values not equal\ngot: %# v\nexpected: %# v",
@@ -101,7 +101,7 @@ func (t *T) AssertEqual(val, ref interface{}) {
 }
 
 // AssertDeepEqual asserts that the value is equal to some reference.
-func (t *T) AssertDeepEqual(val, ref interface{}) {
+func (t *T) AssertDeepEqual(val, ref any) {
 	t.Helper()
 	if !reflect.DeepEqual(val, ref) {
 		t.failWithf(true, "assertion failed: values not equal\ngot: %# v\nexpected: %# v",
@@ -119,7 +119,7 @@ func (t *T) Check(cond bool) {
 }
 
 // CheckEqual checks that the value is equal to some reference.
-func (t *T) CheckEqual(val, ref interface{}) {
+func (t *T) CheckEqual(val, ref any) {
 	t.Helper()
 	if val != ref {
 		t.failWithf(false, "values not equal\n     got: %# v\nexpected: %# v",
@@ -156,7 +156,7 @@ func (t *T) CheckStringEqual(val, ref string) {
 }
 
 // CheckDeepEqual checks that the value is equal to some reference.
-func (t *T) CheckDeepEqual(val, ref interface{}) {
+func (t *T) CheckDeepEqual(val, ref any) {
 	t.Helper()
 	if !reflect.DeepEqual(val, ref) {
 		t.failWithf(false, "values not equal\ngot: %# v\nexpected: %# v",
@@ -178,7 +178,7 @@ func (t *T) CheckRegexpEqual(val, regexs string) {
 	}
 }
 
-func (t *T) failWithf(failTest bool, format string, args ...interface{}) {
+func (t *T) failWithf(failTest bool, format string, args ...any) {
 	t.Helper()
 	_, file, line, _ := runtime.Caller(2)
 	var msg bytes.Buffer


### PR DESCRIPTION
Replace interface{} with the any alias.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/163)
<!-- Reviewable:end -->
